### PR TITLE
Make _delete_piece private, use in board.make_move

### DIFF
--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -142,18 +142,6 @@ def test_move_piece_doesnt_affect_copy():
     assert board2[(4, 4)] is None
 
 
-@pytest.mark.parametrize("position", [(4, 1), (1, 6), (6, 6), (7, 7), (3, 7)])
-def test_delete_piece(position):
-    # given
-    board = Board()
-
-    # when
-    result = board.delete_piece(position=position)
-
-    # then
-    assert result[position] is None
-
-
 def test_board_to_string():
     # given
     board = Board()

--- a/utahchess/board.py
+++ b/utahchess/board.py
@@ -76,14 +76,18 @@ class Board:
         return Board(pieces=new_pieces)
 
     def move_piece(
-        self, from_position: tuple[int, int], to_position: tuple[int, int]
+        self, from_position: tuple[int, int], to_position: Optional[tuple[int, int]]
     ) -> Board:
         """Get a new board with one piece moved to a new position.
 
         If the destination is already occupied, the piece will be lost / captured.
+        If the destination is None, the piece at the origin will be deleted.
         """
         if from_position == to_position:
             return self.copy()
+
+        elif to_position is None:
+            return self._delete_piece(position=from_position)
 
         pieces = self.all_pieces()
         new_pieces = tuple(
@@ -100,7 +104,7 @@ class Board:
         )
         return Board(pieces=new_pieces)
 
-    def delete_piece(self, position: tuple[int, int]) -> Board:
+    def _delete_piece(self, position: Optional[tuple[int, int]]) -> Board:
         """Get a new board with one piece deleted."""
         new_pieces = tuple(
             piece for piece in self.all_pieces() if piece.position != position

--- a/utahchess/en_passant.py
+++ b/utahchess/en_passant.py
@@ -74,7 +74,7 @@ def _complete_en_passant_move(board: Board, en_passant_move: EnPassantMove) -> B
     tile_to_delete = apply_movement_vector(
         position=piece_move[1], movement_vector=(0, -movement_direction)
     )
-    return board.delete_piece(position=tile_to_delete)
+    return board.move_piece(from_position=tile_to_delete, to_position=None)
 
 
 def make_en_passant_move(board: Board, move: EnPassantMove) -> Board:


### PR DESCRIPTION
This PR

- Makes `delete_piece` a private function which is used in `move_piece`
- will help the abstraction for the `Move` class in a future PR. Currently there are three subclasses for `Move` that implement the three different types of moves (regular, castling, en passant). Having this new `move_piece` function will allow for a consolidation of the three move classes (and their respective `make_move` functions).