### PR TITLE
Revert "Make _delete_piece private, use in board.make_move"

### DIFF
--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -142,6 +142,18 @@ def test_move_piece_doesnt_affect_copy():
     assert board2[(4, 4)] is None
 
 
+@pytest.mark.parametrize("position", [(4, 1), (1, 6), (6, 6), (7, 7), (3, 7)])
+def test_delete_piece(position):
+    # given
+    board = Board()
+
+    # when
+    result = board.delete_piece(position=position)
+
+    # then
+    assert result[position] is None
+
+
 def test_board_to_string():
     # given
     board = Board()

--- a/utahchess/board.py
+++ b/utahchess/board.py
@@ -76,18 +76,14 @@ class Board:
         return Board(pieces=new_pieces)
 
     def move_piece(
-        self, from_position: tuple[int, int], to_position: Optional[tuple[int, int]]
+        self, from_position: tuple[int, int], to_position: tuple[int, int]
     ) -> Board:
         """Get a new board with one piece moved to a new position.
 
         If the destination is already occupied, the piece will be lost / captured.
-        If the destination is None, the piece at the origin will be deleted.
         """
         if from_position == to_position:
             return self.copy()
-
-        elif to_position is None:
-            return self._delete_piece(position=from_position)
 
         pieces = self.all_pieces()
         new_pieces = tuple(
@@ -104,7 +100,7 @@ class Board:
         )
         return Board(pieces=new_pieces)
 
-    def _delete_piece(self, position: Optional[tuple[int, int]]) -> Board:
+    def delete_piece(self, position: tuple[int, int]) -> Board:
         """Get a new board with one piece deleted."""
         new_pieces = tuple(
             piece for piece in self.all_pieces() if piece.position != position

--- a/utahchess/en_passant.py
+++ b/utahchess/en_passant.py
@@ -74,7 +74,7 @@ def _complete_en_passant_move(board: Board, en_passant_move: EnPassantMove) -> B
     tile_to_delete = apply_movement_vector(
         position=piece_move[1], movement_vector=(0, -movement_direction)
     )
-    return board.move_piece(from_position=tile_to_delete, to_position=None)
+    return board.delete_piece(position=tile_to_delete)
 
 
 def make_en_passant_move(board: Board, move: EnPassantMove) -> Board:


### PR DESCRIPTION
This reverts commit 178398aac8f384c228337def02879f54db363fe5.

To implement `delete_piece` as a private function called in `move_piece` we need to break the consistency that `piece_moves` always contain non-None values, which makes typing much more complicated. Additionally it just doesn't make much sense to call something a `piece_move` if it doesn't move any pieces but just deletes them. 

To consolidate the three move functions there will be instead a new field in the `Move` class called `pieces_to_delete` which has it's default as `()` but contains the piece to delete when implementing an en passant move.

In the future this public `delete_piece` function might be used to implement promotions, too.