### PR TITLE
Consolidate move classes

### DIFF
--- a/tests/test_castling.py
+++ b/tests/test_castling.py
@@ -4,10 +4,10 @@ from utahchess.board import Board
 from utahchess.castling import (
     LONG_CASTLING,
     SHORT_CASTLING,
-    CastlingMove,
     get_castling_moves,
     make_castling_move,
 )
+from utahchess.move import Move
 
 
 @pytest.mark.parametrize(
@@ -103,13 +103,15 @@ def test_castling_in_corners(
         (rook_from_position, rook_to_position),
     )
     expected = (
-        CastlingMove(
+        Move(
+            type=castling_type,
             piece_moves=expected_piece_moves,
             moving_pieces=(
                 board[king_from_position],
                 board[rook_from_position],
             ),
-            castling_type=castling_type,
+            is_capturing_move=False,
+            allows_en_passant=False,
         ),
     )
 
@@ -181,15 +183,19 @@ def test_castling_both_sides(
         ),
     )
     expected = (
-        CastlingMove(
+        Move(
+            type=SHORT_CASTLING,
             piece_moves=expected_piece_moves_right,
             moving_pieces=(board[king_position], board[rook_position_right]),
-            castling_type=SHORT_CASTLING,
+            is_capturing_move=False,
+            allows_en_passant=False,
         ),
-        CastlingMove(
+        Move(
+            type=LONG_CASTLING,
             piece_moves=expected_piece_moves_left,
             moving_pieces=(board[king_position], board[rook_position_left]),
-            castling_type=LONG_CASTLING,
+            is_capturing_move=False,
+            allows_en_passant=False,
         ),
     )
 
@@ -327,10 +333,12 @@ def test_make_castling_move(
         (king_position, (king_position[0] - 2, king_position[1])),
         (rook_position, (rook_position[0] + 3, rook_position[1])),
     )
-    castling_move = CastlingMove(
+    castling_move = Move(
+        type=LONG_CASTLING,
         piece_moves=expected_piece_moves_left,
         moving_pieces=(board[king_position], board[rook_position]),
-        castling_type=LONG_CASTLING,
+        is_capturing_move=False,
+        allows_en_passant=False,
     )
 
     # when

--- a/tests/test_en_passant.py
+++ b/tests/test_en_passant.py
@@ -6,7 +6,7 @@ from utahchess.en_passant import (
     get_en_passant_moves,
     make_en_passant_move,
 )
-from utahchess.move_validation import RegularMove
+from utahchess.move_validation import REGULAR_MOVE
 
 
 def test_right_side_en_passant_scenario_for_black():
@@ -23,7 +23,8 @@ def test_right_side_en_passant_scenario_for_black():
     board_after_moving_piece = board_before_moving_piece.move_piece(
         from_position=(0, 6), to_position=(0, 4)
     )
-    last_move = RegularMove(
+    last_move = Move(
+        type=REGULAR_MOVE,
         piece_moves=(((0, 6), (0, 4)),),
         moving_pieces=(board_before_moving_piece[0, 6],),
         is_capturing_move=False,
@@ -59,7 +60,8 @@ def test_left_side_en_passant_scenario_for_black():
     board_after_moving_piece = board_before_moving_piece.move_piece(
         from_position=(7, 6), to_position=(7, 4)
     )
-    last_move = RegularMove(
+    last_move = Move(
+        type=REGULAR_MOVE,
         piece_moves=(((7, 6), (7, 4)),),
         moving_pieces=(board_before_moving_piece[7, 6],),
         is_capturing_move=False,
@@ -95,7 +97,8 @@ def test_right_side_en_passant_scenario_for_white():
     board_after_moving_piece = board_before_moving_piece.move_piece(
         from_position=(0, 1), to_position=(0, 3)
     )
-    last_move = RegularMove(
+    last_move = Move(
+        type=REGULAR_MOVE,
         piece_moves=(((0, 1), (0, 3)),),
         moving_pieces=(board_before_moving_piece[0, 1],),
         is_capturing_move=False,
@@ -131,7 +134,8 @@ def test_left_side_en_passant_scenario_for_white():
     board_after_moving_piece = board_before_moving_piece.move_piece(
         from_position=(1, 1), to_position=(1, 3)
     )
-    last_move = RegularMove(
+    last_move = Move(
+        type=REGULAR_MOVE,
         piece_moves=(((1, 1), (1, 3)),),
         moving_pieces=(board_before_moving_piece[1, 1],),
         is_capturing_move=False,
@@ -242,7 +246,8 @@ def test_last_move_allows_en_passant_but_no_pawn_nearby(
     board_after_moving_piece = board_before_moving_piece.move_piece(
         from_position=last_move_initial, to_position=last_move_destination
     )
-    last_move = RegularMove(
+    last_move = Move(
+        type=REGULAR_MOVE,
         piece_moves=((last_move_initial, last_move_destination),),
         moving_pieces=(board_before_moving_piece[last_move_initial],),
         is_capturing_move=False,
@@ -273,7 +278,8 @@ def test_get_en_passant_moves_would_leave_king_in_check_black():
     board_after_moving_piece = board_before_moving_piece.move_piece(
         from_position=(2, 6), to_position=(2, 4)
     )
-    last_move = RegularMove(
+    last_move = Move(
+        type=REGULAR_MOVE,
         piece_moves=(((2, 6), (2, 4)),),
         moving_pieces=(board_before_moving_piece[2, 6],),
         is_capturing_move=False,
@@ -304,7 +310,8 @@ def test_get_en_passant_moves_would_leave_king_in_check_white():
     board_after_moving_piece = board_before_moving_piece.move_piece(
         from_position=(2, 1), to_position=(2, 3)
     )
-    last_move = RegularMove(
+    last_move = Move(
+        type=REGULAR_MOVE,
         piece_moves=(((2, 1), (2, 3)),),
         moving_pieces=(board_before_moving_piece[2, 1],),
         is_capturing_move=False,
@@ -335,7 +342,8 @@ def test_both_sides_en_passant_scenario_for_white():
     board_after_moving_piece = board_before_moving_piece.move_piece(
         from_position=(1, 1), to_position=(1, 3)
     )
-    last_move = RegularMove(
+    last_move = Move(
+        type=REGULAR_MOVE,
         piece_moves=(((1, 1), (1, 3)),),
         moving_pieces=(board_before_moving_piece[1, 1],),
         is_capturing_move=False,
@@ -375,7 +383,8 @@ def test_both_sides_en_passant_scenario_for_black():
     board_after_moving_piece = board_before_moving_piece.move_piece(
         from_position=(1, 6), to_position=(1, 4)
     )
-    last_move = RegularMove(
+    last_move = Move(
+        type=REGULAR_MOVE,
         piece_moves=(((1, 6), (1, 4)),),
         moving_pieces=(board_before_moving_piece[1, 6],),
         is_capturing_move=False,

--- a/tests/test_en_passant.py
+++ b/tests/test_en_passant.py
@@ -2,10 +2,11 @@ import pytest
 
 from utahchess.board import Board
 from utahchess.en_passant import (
-    EnPassantMove,
+    EN_PASSANT_MOVE,
     get_en_passant_moves,
     make_en_passant_move,
 )
+from utahchess.move import Move
 from utahchess.move_validation import REGULAR_MOVE
 
 
@@ -38,9 +39,13 @@ def test_right_side_en_passant_scenario_for_black():
 
     # then
     expected = (
-        EnPassantMove(
+        Move(
+            type=EN_PASSANT_MOVE,
             piece_moves=(((1, 4), (0, 5)),),
             moving_pieces=(board_after_moving_piece[1, 4],),
+            pieces_to_delete=((0, 4),),
+            is_capturing_move=True,
+            allows_en_passant=False,
         ),
     )
     assert expected == actual
@@ -75,9 +80,13 @@ def test_left_side_en_passant_scenario_for_black():
 
     # then
     expected = (
-        EnPassantMove(
+        Move(
+            type=EN_PASSANT_MOVE,
             piece_moves=(((6, 4), (7, 5)),),
             moving_pieces=(board_after_moving_piece[6, 4],),
+            pieces_to_delete=((7, 4),),
+            is_capturing_move=True,
+            allows_en_passant=False,
         ),
     )
     assert expected == actual
@@ -112,9 +121,13 @@ def test_right_side_en_passant_scenario_for_white():
 
     # then
     expected = (
-        EnPassantMove(
+        Move(
+            type=EN_PASSANT_MOVE,
             piece_moves=(((1, 3), (0, 2)),),
             moving_pieces=(board_after_moving_piece[1, 3],),
+            pieces_to_delete=((0, 3),),
+            is_capturing_move=True,
+            allows_en_passant=False,
         ),
     )
     assert expected == actual
@@ -149,9 +162,13 @@ def test_left_side_en_passant_scenario_for_white():
 
     # then
     expected = (
-        EnPassantMove(
+        Move(
+            type=EN_PASSANT_MOVE,
             piece_moves=(((0, 3), (1, 2)),),
             moving_pieces=(board_after_moving_piece[0, 3],),
+            pieces_to_delete=((1, 3),),
+            is_capturing_move=True,
+            allows_en_passant=False,
         ),
     )
     assert actual == expected
@@ -357,13 +374,21 @@ def test_both_sides_en_passant_scenario_for_white():
 
     # then
     expected = (
-        EnPassantMove(
+        Move(
+            type=EN_PASSANT_MOVE,
             piece_moves=(((2, 3), (1, 2)),),
             moving_pieces=(board_after_moving_piece[2, 3],),
+            pieces_to_delete=((1, 3),),
+            is_capturing_move=True,
+            allows_en_passant=False,
         ),
-        EnPassantMove(
+        Move(
+            type=EN_PASSANT_MOVE,
             piece_moves=(((0, 3), (1, 2)),),
             moving_pieces=(board_after_moving_piece[0, 3],),
+            pieces_to_delete=((1, 3),),
+            is_capturing_move=True,
+            allows_en_passant=False,
         ),
     )
     assert expected == actual
@@ -398,20 +423,34 @@ def test_both_sides_en_passant_scenario_for_black():
 
     # then
     expected = (
-        EnPassantMove(
+        Move(
+            type=EN_PASSANT_MOVE,
             piece_moves=(((2, 4), (1, 5)),),
             moving_pieces=(board_after_moving_piece[2, 4],),
+            pieces_to_delete=((1, 4),),
+            is_capturing_move=True,
+            allows_en_passant=False,
         ),
-        EnPassantMove(
+        Move(
+            type=EN_PASSANT_MOVE,
             piece_moves=(((0, 4), (1, 5)),),
             moving_pieces=(board_after_moving_piece[0, 4],),
+            pieces_to_delete=((1, 4),),
+            is_capturing_move=True,
+            allows_en_passant=False,
         ),
     )
     assert expected == actual
 
 
 @pytest.mark.parametrize(
-    ("intial_board", "expected_board", "en_passant_from", "en_passant_to"),
+    (
+        "intial_board",
+        "expected_board",
+        "en_passant_from",
+        "en_passant_to",
+        "piece_to_delete",
+    ),
     [
         (
             Board(
@@ -436,6 +475,7 @@ def test_both_sides_en_passant_scenario_for_black():
             ),
             (2, 4),
             (1, 5),
+            (1, 4),
         ),
         (
             Board(
@@ -460,6 +500,7 @@ def test_both_sides_en_passant_scenario_for_black():
             ),
             (0, 4),
             (1, 5),
+            (1, 4),
         ),
         (
             Board(
@@ -484,6 +525,7 @@ def test_both_sides_en_passant_scenario_for_black():
             ),
             (2, 3),
             (1, 2),
+            (1, 3),
         ),
         (
             Board(
@@ -508,17 +550,26 @@ def test_both_sides_en_passant_scenario_for_black():
             ),
             (0, 3),
             (1, 2),
+            (1, 3),
         ),
     ],
 )
 def test_make_en_passant_move(
-    intial_board, expected_board, en_passant_from, en_passant_to
+    intial_board,
+    expected_board,
+    en_passant_from,
+    en_passant_to,
+    piece_to_delete,
 ):
 
     # given
-    en_passant_move = EnPassantMove(
+    en_passant_move = Move(
+        type=EN_PASSANT_MOVE,
         piece_moves=((en_passant_from, en_passant_to),),
         moving_pieces=(intial_board[en_passant_from],),
+        pieces_to_delete=(),
+        is_capturing_move=True,
+        allows_en_passant=False,
     )
 
     # when

--- a/tests/test_legal_moves.py
+++ b/tests/test_legal_moves.py
@@ -9,7 +9,7 @@ from utahchess.legal_moves import (
     x_index_to_file,
     y_index_to_rank,
 )
-from utahchess.move_validation import RegularMove, make_regular_move
+from utahchess.move_validation import REGULAR_MOVE, make_regular_move
 
 
 @pytest.mark.parametrize(
@@ -318,7 +318,8 @@ def test_get_algebraic_notation_mapping_with_last_move_for_en_passant(
 ):
     # given
     board = Board(board_string=board_string)
-    move_to_make = RegularMove(
+    move_to_make = Move(
+        type=REGULAR_MOVE,
         piece_moves=pawn_move,
         moving_pieces=(board[pawn_move[0][0]],),
         is_capturing_move=False,

--- a/tests/test_legal_moves.py
+++ b/tests/test_legal_moves.py
@@ -1,6 +1,7 @@
 import pytest
 
 from utahchess.board import Board
+from utahchess.move import Move
 from utahchess.legal_moves import (
     file_to_x_index,
     get_algebraic_notation_mapping,

--- a/tests/test_move_validation.py
+++ b/tests/test_move_validation.py
@@ -1,9 +1,10 @@
 import pytest
 
 from utahchess.board import Board
+from utahchess.move import Move
 from utahchess.move_candidates import get_king_move_candidates, get_pawn_move_candidates
 from utahchess.move_validation import (
-    RegularMove,
+    REGULAR_MOVE,
     is_checkmate,
     make_regular_move,
     validate_move_candidates,
@@ -92,7 +93,8 @@ def test_validate_move_candidates_restricted_king():
 
     # then
     assert result == (
-        RegularMove(
+        Move(
+            type=REGULAR_MOVE,
             piece_moves=(((7, 6), (6, 7)),),
             moving_pieces=(board[7, 6],),
             is_capturing_move=False,
@@ -176,7 +178,8 @@ def test_validate_move_candidates_pawn_cant_move():
 )
 def test_make_regular_move(board, from_move, to_move, expected):
     # given
-    regular_move = RegularMove(
+    regular_move = Move(
+        type=REGULAR_MOVE,
         piece_moves=((from_move, to_move),),
         moving_pieces=board[from_move],
         is_capturing_move=False,

--- a/utahchess/legal_moves.py
+++ b/utahchess/legal_moves.py
@@ -7,10 +7,8 @@ from typing import Generator, Optional, Sequence
 from utahchess.algebraic_notation import AlgebraicNotation
 from utahchess.board import Board
 from utahchess.castling import (
-    CASTLING_MOVE,
     LONG_CASTLING,
     SHORT_CASTLING,
-    CastlingMove,
     get_castling_moves,
     make_castling_move,
 )
@@ -53,7 +51,7 @@ def get_algebraic_notation_mapping(
 def make_move(board: Board, move: Move) -> Board:
     if move.type == REGULAR_MOVE:
         return make_regular_move(board=board, move=move)  # type: ignore
-    elif move.type == CASTLING_MOVE:
+    elif move.type == SHORT_CASTLING or move.type == LONG_CASTLING:
         return make_castling_move(board=board, move=move)  # type: ignore
     elif move.type == EN_PASSANT_MOVE:
         return make_en_passant_move(board=board, move=move)  # type: ignore
@@ -147,14 +145,13 @@ def _get_capturing_flag(move: Move) -> str:
     return "x" if move.is_capturing_move else ""
 
 
-def _get_castling_move_algebraic_notation(move: CastlingMove) -> str:
-    if not move.type == CASTLING_MOVE:
-        return ""
-    if move.castling_type == SHORT_CASTLING:
+def _get_castling_move_algebraic_notation(move: Move) -> str:
+    if move.type == SHORT_CASTLING:
         return "O-O"
-    elif move.castling_type == LONG_CASTLING:
+    elif move.type == LONG_CASTLING:
         return "O-O-O"
-    raise Exception(f"{move} is not a valid Castling Move")
+    else:
+        return ""
 
 
 def _disambiguate_moves(

--- a/utahchess/move.py
+++ b/utahchess/move.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-import abc
+from dataclasses import dataclass
 
 from utahchess.piece import Piece
 
 
-class Move(abc.ABC):
+@dataclass(frozen=True)
+class Move:
     type: str
     piece_moves: tuple[tuple[tuple[int, int], tuple[int, int]], ...]
     moving_pieces: tuple[Piece, ...]
     is_capturing_move: bool
     allows_en_passant: bool
+    pieces_to_delete: tuple[tuple[int, int], ...] = ()

--- a/utahchess/move_validation.py
+++ b/utahchess/move_validation.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Generator
 
 from utahchess.board import Board
@@ -9,15 +8,6 @@ from utahchess.move_candidates import get_all_move_candidates
 from utahchess.piece import Piece
 
 REGULAR_MOVE = "Regular Move"
-
-
-@dataclass(frozen=True)
-class RegularMove(Move):
-    type = REGULAR_MOVE
-    piece_moves: tuple[tuple[tuple[int, int], tuple[int, int]], ...]
-    moving_pieces: tuple[Piece, ...]
-    is_capturing_move: bool
-    allows_en_passant: bool
 
 
 def _set_allows_en_passant_flag(
@@ -86,7 +76,7 @@ def is_checkmate(board: Board, current_player: str) -> bool:
 def validate_move_candidates(
     board: Board,
     move_candidates: Generator[tuple[tuple[int, int], tuple[int, int]], None, None],
-) -> Generator[RegularMove, None, None]:
+) -> Generator[Move, None, None]:
     """Filter move candidates based on whether they leave king unprotected."""
 
     for move_candidate in move_candidates:
@@ -104,7 +94,8 @@ def validate_move_candidates(
         destination = board[to_position]
         is_capturing_move = False if destination is None else True
         if not is_check(board=board_after_move, current_player=current_player):
-            yield RegularMove(
+            yield Move(
+                type=REGULAR_MOVE,
                 piece_moves=(move_candidate,),
                 moving_pieces=(from_piece,),
                 is_capturing_move=is_capturing_move,
@@ -116,13 +107,13 @@ def validate_move_candidates(
 
 def get_legal_regular_moves(
     board: Board, current_player: str
-) -> Generator[RegularMove, None, None]:
+) -> Generator[Move, None, None]:
     all_move_candidates = get_all_move_candidates(
         board=board, current_player=current_player
     )
     return validate_move_candidates(board=board, move_candidates=all_move_candidates)
 
 
-def make_regular_move(board: Board, move: RegularMove) -> Board:
+def make_regular_move(board: Board, move: Move) -> Board:
     from_position, to_position = move.piece_moves[0]
     return board.move_piece(from_position=from_position, to_position=to_position)


### PR DESCRIPTION
This PR

- Converts the `Move` class into an actual implemented `dataclass` instead of just being an ABC
- Removes the individual implementations of the three move types (Regular, Castling, En Passant)
- Allows to consolidate the individual `make_<type>_move` functions into one `make_move` function