### PR TITLE
Consolidate all make_<type>_move functions

### DIFF
--- a/tests/test_castling.py
+++ b/tests/test_castling.py
@@ -1,12 +1,8 @@
 import pytest
 
 from utahchess.board import Board
-from utahchess.castling import (
-    LONG_CASTLING,
-    SHORT_CASTLING,
-    get_castling_moves,
-    make_castling_move,
-)
+from utahchess.castling import LONG_CASTLING, SHORT_CASTLING, get_castling_moves
+from utahchess.legal_moves import make_move
 from utahchess.move import Move
 
 
@@ -342,7 +338,7 @@ def test_make_castling_move(
     )
 
     # when
-    actual = make_castling_move(board=board, move=castling_move)
+    actual = make_move(board=board, move=castling_move)
 
     # then
     assert Board(board_string=expected_board_after_move) == actual

--- a/tests/test_en_passant.py
+++ b/tests/test_en_passant.py
@@ -1,11 +1,8 @@
 import pytest
 
 from utahchess.board import Board
-from utahchess.en_passant import (
-    EN_PASSANT_MOVE,
-    get_en_passant_moves,
-    make_en_passant_move,
-)
+from utahchess.en_passant import EN_PASSANT_MOVE, get_en_passant_moves
+from utahchess.legal_moves import make_move
 from utahchess.move import Move
 from utahchess.move_validation import REGULAR_MOVE
 
@@ -567,13 +564,13 @@ def test_make_en_passant_move(
         type=EN_PASSANT_MOVE,
         piece_moves=((en_passant_from, en_passant_to),),
         moving_pieces=(intial_board[en_passant_from],),
-        pieces_to_delete=(),
+        pieces_to_delete=((piece_to_delete),),
         is_capturing_move=True,
         allows_en_passant=False,
     )
 
     # when
-    actual = make_en_passant_move(
+    actual = make_move(
         board=intial_board,
         move=en_passant_move,
     )

--- a/tests/test_legal_moves.py
+++ b/tests/test_legal_moves.py
@@ -1,16 +1,17 @@
 import pytest
 
 from utahchess.board import Board
-from utahchess.move import Move
 from utahchess.legal_moves import (
     file_to_x_index,
     get_algebraic_notation_mapping,
     is_stalemate,
+    make_move,
     rank_to_y_index,
     x_index_to_file,
     y_index_to_rank,
 )
-from utahchess.move_validation import REGULAR_MOVE, make_regular_move
+from utahchess.move import Move
+from utahchess.move_validation import REGULAR_MOVE
 
 
 @pytest.mark.parametrize(
@@ -326,7 +327,7 @@ def test_get_algebraic_notation_mapping_with_last_move_for_en_passant(
         is_capturing_move=False,
         allows_en_passant=True,
     )
-    board_after_move = make_regular_move(board=board, move=move_to_make)
+    board_after_move = make_move(board=board, move=move_to_make)
 
     # when
     result = tuple(

--- a/tests/test_move_validation.py
+++ b/tests/test_move_validation.py
@@ -1,12 +1,12 @@
 import pytest
 
 from utahchess.board import Board
+from utahchess.legal_moves import make_move
 from utahchess.move import Move
 from utahchess.move_candidates import get_king_move_candidates, get_pawn_move_candidates
 from utahchess.move_validation import (
     REGULAR_MOVE,
     is_checkmate,
-    make_regular_move,
     validate_move_candidates,
 )
 
@@ -187,7 +187,7 @@ def test_make_regular_move(board, from_move, to_move, expected):
     )
 
     # when
-    result = make_regular_move(board=board, move=regular_move)
+    result = make_move(board=board, move=regular_move)
 
     # then
     assert result == expected

--- a/utahchess/castling.py
+++ b/utahchess/castling.py
@@ -68,17 +68,6 @@ def get_king_move(move: Move) -> tuple[tuple[int, int], tuple[int, int]]:
     return move.piece_moves[0]
 
 
-def make_castling_move(board: Board, move: Move) -> Board:
-    rook_from, rook_to = get_rook_move(move=move)
-    king_from, king_to = get_king_move(move=move)
-    board_after_rook_move = board.move_piece(
-        from_position=rook_from, to_position=rook_to
-    )
-    return board_after_rook_move.move_piece(
-        from_position=king_from, to_position=king_to
-    )
-
-
 def _get_castling_type(movement_vector: tuple[int, int]) -> str:
     return SHORT_CASTLING if movement_vector[0] == 1 else LONG_CASTLING
 

--- a/utahchess/en_passant.py
+++ b/utahchess/en_passant.py
@@ -4,7 +4,7 @@ from typing import Generator, Optional
 
 from utahchess.board import Board
 from utahchess.move import Move
-from utahchess.move_validation import validate_move
+from utahchess.move_validation import is_valid_move
 from utahchess.tile_movement_utils import apply_movement_vector, is_in_bounds
 
 EN_PASSANT_MOVE = "En Passant Move"
@@ -59,7 +59,7 @@ def get_en_passant_moves(
                 is_capturing_move=True,
                 allows_en_passant=False,
             )
-            if validate_move(board=board, move=potential_move):
+            if is_valid_move(board=board, move=potential_move):
                 yield potential_move
 
 

--- a/utahchess/en_passant.py
+++ b/utahchess/en_passant.py
@@ -4,8 +4,7 @@ from typing import Generator, Optional
 
 from utahchess.board import Board
 from utahchess.move import Move
-from utahchess.move_validation import is_check
-from utahchess.piece import Piece
+from utahchess.move_validation import validate_move
 from utahchess.tile_movement_utils import apply_movement_vector, is_in_bounds
 
 EN_PASSANT_MOVE = "En Passant Move"
@@ -39,6 +38,7 @@ def get_en_passant_moves(
             continue
 
         opponent_piece = board[last_move.piece_moves[0][1]]
+
         if opponent_piece is None:
             raise Exception(
                 f"Piece at position {last_move.piece_moves[0][1]} is None when it should be a Pawn."
@@ -59,7 +59,7 @@ def get_en_passant_moves(
                 is_capturing_move=True,
                 allows_en_passant=False,
             )
-            if _is_valid_en_passant_move(board=board, en_passant_move=potential_move):
+            if validate_move(board=board, move=potential_move):
                 yield potential_move
 
 
@@ -72,26 +72,3 @@ def _get_piece_to_delete(
             position=piece_move[1], movement_vector=(0, -movement_direction)
         ),
     )
-
-
-def _complete_en_passant_move(board: Board, en_passant_move: Move) -> Board:
-    """Completes the capturing part of an en passant move."""
-    piece_move = en_passant_move.piece_moves[0]
-    movement_direction = piece_move[1][1] - piece_move[0][1]
-    tile_to_delete = apply_movement_vector(
-        position=piece_move[1], movement_vector=(0, -movement_direction)
-    )
-    return board.delete_piece(position=tile_to_delete)
-
-
-def make_en_passant_move(board: Board, move: Move) -> Board:
-    piece_move = move.piece_moves[0]
-    board = board.move_piece(from_position=piece_move[0], to_position=piece_move[1])
-    board = _complete_en_passant_move(board=board, en_passant_move=move)
-    return board
-
-
-def _is_valid_en_passant_move(board: Board, en_passant_move: Move) -> bool:
-    current_player = en_passant_move.moving_pieces[0].color
-    board_after_move = make_en_passant_move(board=board, move=en_passant_move)
-    return not is_check(board=board_after_move, current_player=current_player)

--- a/utahchess/legal_moves.py
+++ b/utahchess/legal_moves.py
@@ -6,25 +6,10 @@ from typing import Generator, Optional, Sequence
 
 from utahchess.algebraic_notation import AlgebraicNotation
 from utahchess.board import Board
-from utahchess.castling import (
-    LONG_CASTLING,
-    SHORT_CASTLING,
-    get_castling_moves,
-    make_castling_move,
-)
-from utahchess.en_passant import (
-    EN_PASSANT_MOVE,
-    get_en_passant_moves,
-    make_en_passant_move,
-)
+from utahchess.castling import LONG_CASTLING, SHORT_CASTLING, get_castling_moves
+from utahchess.en_passant import EN_PASSANT_MOVE, get_en_passant_moves
 from utahchess.move import Move
-from utahchess.move_validation import (
-    REGULAR_MOVE,
-    get_legal_regular_moves,
-    is_check,
-    is_checkmate,
-    make_regular_move,
-)
+from utahchess.move_validation import get_legal_regular_moves, is_check, is_checkmate
 
 FILE_POSSIBILITIES = "abcdefgh"
 RANK_POSSIBILITIES = "87654321"
@@ -49,15 +34,14 @@ def get_algebraic_notation_mapping(
 
 
 def make_move(board: Board, move: Move) -> Board:
-    if move.type == REGULAR_MOVE:
-        return make_regular_move(board=board, move=move)  # type: ignore
-    elif move.type == SHORT_CASTLING or move.type == LONG_CASTLING:
-        return make_castling_move(board=board, move=move)  # type: ignore
-    elif move.type == EN_PASSANT_MOVE:
-        return make_en_passant_move(board=board, move=move)  # type: ignore
-    raise Exception(
-        f"Move {move} did not match any of the move types when trying to make a move."
-    )
+    board_after_move = board.copy()
+    for piece_move in move.piece_moves:
+        board_after_move = board_after_move.move_piece(
+            from_position=piece_move[0], to_position=piece_move[1]
+        )
+    for piece_to_delete in move.pieces_to_delete:
+        board_after_move = board_after_move.delete_piece(position=piece_to_delete)
+    return board_after_move
 
 
 def x_index_to_file(x: int) -> str:
@@ -114,8 +98,8 @@ def _get_all_legal_moves(
     board: Board, current_player: str, last_move: Optional[Move]
 ) -> Generator[Move, None, None]:
     regular_moves = get_legal_regular_moves(board=board, current_player=current_player)
-    en_passant_moves = get_en_passant_moves(board=board, last_move=last_move)
     castling_moves = get_castling_moves(board=board, current_player=current_player)
+    en_passant_moves = get_en_passant_moves(board=board, last_move=last_move)
     return chain(regular_moves, en_passant_moves, castling_moves)  # type: ignore
 
 

--- a/utahchess/move_validation.py
+++ b/utahchess/move_validation.py
@@ -66,7 +66,7 @@ def is_checkmate(board: Board, current_player: str) -> bool:
     return is_check(board=board, current_player=current_player)
 
 
-def validate_move(board: Board, move: Move) -> bool:
+def is_valid_move(board: Board, move: Move) -> bool:
     board_after_move = board.copy()
     current_player = board[move.piece_moves[0][0]].color  # type: ignore
     for piece_move in move.piece_moves:


### PR DESCRIPTION
This PR

- consolidates `make_regular_move` and `make_en_passant_move`, `make_castling_move` functions into `make_move` function
- creates a new function `is_valid_move` which is used to validate en passant moves. This function will be used in a later PR to further simplify construction of regular moves.