### PR TITLE
Refactor move_validation module by introducing regular_move module

### DIFF
--- a/tests/test_en_passant.py
+++ b/tests/test_en_passant.py
@@ -4,7 +4,7 @@ from utahchess.board import Board
 from utahchess.en_passant import EN_PASSANT_MOVE, get_en_passant_moves
 from utahchess.legal_moves import make_move
 from utahchess.move import Move
-from utahchess.move_validation import REGULAR_MOVE
+from utahchess.regular_move import REGULAR_MOVE
 
 
 def test_right_side_en_passant_scenario_for_black():

--- a/tests/test_legal_moves.py
+++ b/tests/test_legal_moves.py
@@ -11,7 +11,7 @@ from utahchess.legal_moves import (
     y_index_to_rank,
 )
 from utahchess.move import Move
-from utahchess.move_validation import REGULAR_MOVE
+from utahchess.regular_move import REGULAR_MOVE
 
 
 @pytest.mark.parametrize(

--- a/tests/test_move_validation.py
+++ b/tests/test_move_validation.py
@@ -4,11 +4,7 @@ from utahchess.board import Board
 from utahchess.legal_moves import make_move
 from utahchess.move import Move
 from utahchess.move_candidates import get_king_move_candidates, get_pawn_move_candidates
-from utahchess.move_validation import (
-    REGULAR_MOVE,
-    is_checkmate,
-    validate_move_candidates,
-)
+from utahchess.move_validation import is_checkmate
 
 
 def test_is_checkmate_fools_mate():
@@ -75,119 +71,119 @@ def test_is_checkmate_another_scenario():
     assert not is_checkmate(board=board, current_player="black")
 
 
-def test_validate_move_candidates_restricted_king():
-    # when
-    board_string = f"""oo-bn-bb-oo-oo-bb-oo-oo
-            oo-oo-oo-oo-bn-oo-oo-br
-            oo-oo-bp-oo-oo-oo-bn-oo
-            oo-oo-bp-oo-bp-oo-oo-bp
-            oo-oo-oo-wq-wn-bp-oo-wp
-            wb-oo-oo-wp-oo-oo-oo-oo
-            br-oo-oo-oo-oo-oo-oo-wk
-            oo-oo-oo-oo-oo-wb-oo-wr"""
-    board = Board(board_string=board_string)
-    move_candidates = get_king_move_candidates(board=board, position=(7, 6))
-    result = tuple(
-        validate_move_candidates(board=board, move_candidates=move_candidates)
-    )
+# def test_validate_move_candidates_restricted_king():
+#     # when
+#     board_string = f"""oo-bn-bb-oo-oo-bb-oo-oo
+#             oo-oo-oo-oo-bn-oo-oo-br
+#             oo-oo-bp-oo-oo-oo-bn-oo
+#             oo-oo-bp-oo-bp-oo-oo-bp
+#             oo-oo-oo-wq-wn-bp-oo-wp
+#             wb-oo-oo-wp-oo-oo-oo-oo
+#             br-oo-oo-oo-oo-oo-oo-wk
+#             oo-oo-oo-oo-oo-wb-oo-wr"""
+#     board = Board(board_string=board_string)
+#     move_candidates = get_king_move_candidates(board=board, position=(7, 6))
+#     result = tuple(
+#         validate_move_candidates(board=board, move_candidates=move_candidates)
+#     )
 
-    # then
-    assert result == (
-        Move(
-            type=REGULAR_MOVE,
-            piece_moves=(((7, 6), (6, 7)),),
-            moving_pieces=(board[7, 6],),
-            is_capturing_move=False,
-            allows_en_passant=False,
-        ),
-    )
-
-
-def test_validate_move_candidates_pawn_cant_move():
-    # when
-    board_string = f"""oo-bn-bb-oo-oo-bb-oo-oo
-            bk-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-br-oo-wp-wk
-            oo-oo-oo-oo-oo-oo-oo-oo"""
-    board = Board(board_string=board_string)
-    move_candidates = get_pawn_move_candidates(board=board, position=(6, 6))
-    result = tuple(
-        validate_move_candidates(board=board, move_candidates=move_candidates)
-    )
-
-    # then
-    assert result == ()
+#     # then
+#     assert result == (
+#         Move(
+#             type=REGULAR_MOVE,
+#             piece_moves=(((7, 6), (6, 7)),),
+#             moving_pieces=(board[7, 6],),
+#             is_capturing_move=False,
+#             allows_en_passant=False,
+#         ),
+#     )
 
 
-@pytest.mark.parametrize(
-    ("board", "from_move", "to_move", "expected"),
-    [
-        (
-            Board(
-                board_string=f"""bk-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-bp-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-wp-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-wk""",
-            ),
-            (7, 7),
-            (7, 6),
-            Board(
-                board_string=f"""bk-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-bp-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-wp-oo-oo-oo-wk
-            oo-oo-oo-oo-oo-oo-oo-oo""",
-            ),
-        ),
-        (
-            Board(
-                board_string=f"""bk-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-bp-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-wp-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-wk""",
-            ),
-            (4, 4),
-            (4, 5),
-            Board(
-                board_string=f"""bk-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-bp-oo-oo-oo
-            oo-oo-oo-wp-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-wk""",
-            ),
-        ),
-    ],
-)
-def test_make_regular_move(board, from_move, to_move, expected):
-    # given
-    regular_move = Move(
-        type=REGULAR_MOVE,
-        piece_moves=((from_move, to_move),),
-        moving_pieces=board[from_move],
-        is_capturing_move=False,
-        allows_en_passant=False,
-    )
+# def test_validate_move_candidates_pawn_cant_move():
+#     # when
+#     board_string = f"""oo-bn-bb-oo-oo-bb-oo-oo
+#             bk-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-br-oo-wp-wk
+#             oo-oo-oo-oo-oo-oo-oo-oo"""
+#     board = Board(board_string=board_string)
+#     move_candidates = get_pawn_move_candidates(board=board, position=(6, 6))
+#     result = tuple(
+#         validate_move_candidates(board=board, move_candidates=move_candidates)
+#     )
 
-    # when
-    result = make_move(board=board, move=regular_move)
+#     # then
+#     assert result == ()
 
-    # then
-    assert result == expected
+
+# @pytest.mark.parametrize(
+#     ("board", "from_move", "to_move", "expected"),
+#     [
+#         (
+#             Board(
+#                 board_string=f"""bk-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-bp-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-wp-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-wk""",
+#             ),
+#             (7, 7),
+#             (7, 6),
+#             Board(
+#                 board_string=f"""bk-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-bp-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-wp-oo-oo-oo-wk
+#             oo-oo-oo-oo-oo-oo-oo-oo""",
+#             ),
+#         ),
+#         (
+#             Board(
+#                 board_string=f"""bk-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-bp-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-wp-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-wk""",
+#             ),
+#             (4, 4),
+#             (4, 5),
+#             Board(
+#                 board_string=f"""bk-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-oo
+#             oo-oo-oo-oo-bp-oo-oo-oo
+#             oo-oo-oo-wp-oo-oo-oo-oo
+#             oo-oo-oo-oo-oo-oo-oo-wk""",
+#             ),
+#         ),
+#     ],
+# )
+# def test_make_regular_move(board, from_move, to_move, expected):
+#     # given
+#     regular_move = Move(
+#         type=REGULAR_MOVE,
+#         piece_moves=((from_move, to_move),),
+#         moving_pieces=board[from_move],
+#         is_capturing_move=False,
+#         allows_en_passant=False,
+#     )
+
+#     # when
+#     result = make_move(board=board, move=regular_move)
+
+#     # then
+#     assert result == expected

--- a/tests/test_move_validation.py
+++ b/tests/test_move_validation.py
@@ -4,7 +4,8 @@ from utahchess.board import Board
 from utahchess.legal_moves import make_move
 from utahchess.move import Move
 from utahchess.move_candidates import get_king_move_candidates, get_pawn_move_candidates
-from utahchess.move_validation import is_checkmate
+from utahchess.move_validation import is_check, is_checkmate, is_valid_move
+from utahchess.regular_move import REGULAR_MOVE
 
 
 def test_is_checkmate_fools_mate():
@@ -71,119 +72,156 @@ def test_is_checkmate_another_scenario():
     assert not is_checkmate(board=board, current_player="black")
 
 
-# def test_validate_move_candidates_restricted_king():
-#     # when
-#     board_string = f"""oo-bn-bb-oo-oo-bb-oo-oo
-#             oo-oo-oo-oo-bn-oo-oo-br
-#             oo-oo-bp-oo-oo-oo-bn-oo
-#             oo-oo-bp-oo-bp-oo-oo-bp
-#             oo-oo-oo-wq-wn-bp-oo-wp
-#             wb-oo-oo-wp-oo-oo-oo-oo
-#             br-oo-oo-oo-oo-oo-oo-wk
-#             oo-oo-oo-oo-oo-wb-oo-wr"""
-#     board = Board(board_string=board_string)
-#     move_candidates = get_king_move_candidates(board=board, position=(7, 6))
-#     result = tuple(
-#         validate_move_candidates(board=board, move_candidates=move_candidates)
-#     )
+def test_is_valid_move_restricted_king():
+    # when
+    board_string = f"""oo-bn-bb-oo-oo-bb-oo-oo
+            oo-oo-oo-oo-bn-oo-oo-br
+            oo-oo-bp-oo-oo-oo-bn-oo
+            oo-oo-bp-oo-bp-oo-oo-bp
+            oo-oo-oo-wq-wn-bp-oo-wp
+            wb-oo-oo-wp-oo-oo-oo-oo
+            br-oo-oo-oo-oo-oo-oo-wk
+            oo-oo-oo-oo-oo-wb-oo-wr"""
+    board = Board(board_string=board_string)
 
-#     # then
-#     assert result == (
-#         Move(
-#             type=REGULAR_MOVE,
-#             piece_moves=(((7, 6), (6, 7)),),
-#             moving_pieces=(board[7, 6],),
-#             is_capturing_move=False,
-#             allows_en_passant=False,
-#         ),
-#     )
+    invalid_king_destinations = ((6, 6), (6, 5), (7, 5))
+    invalid_king_moves = tuple(
+        Move(
+            type=REGULAR_MOVE,
+            piece_moves=(((7, 6), invalid_king_destination),),
+            moving_pieces=(board[7, 6],),
+            is_capturing_move=False,
+            allows_en_passant=False,
+        )
+        for invalid_king_destination in invalid_king_destinations
+    )
+
+    valid_king_destinations = ((6, 7),)
+    valid_king_moves = tuple(
+        Move(
+            type=REGULAR_MOVE,
+            piece_moves=(((7, 6), valid_king_destination),),
+            moving_pieces=(board[7, 6],),
+            is_capturing_move=False,
+            allows_en_passant=False,
+        )
+        for valid_king_destination in valid_king_destinations
+    )
+
+    # then
+    assert all(not is_valid_move(board=board, move=move) for move in invalid_king_moves)
+    assert all(is_valid_move(board=board, move=move) for move in valid_king_moves)
+    assert (
+        len(
+            tuple(
+                get_king_move_candidates(
+                    board=board,
+                    position=(7, 6),
+                )
+            )
+        )
+        == 4
+    )
 
 
-# def test_validate_move_candidates_pawn_cant_move():
-#     # when
-#     board_string = f"""oo-bn-bb-oo-oo-bb-oo-oo
-#             bk-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-br-oo-wp-wk
-#             oo-oo-oo-oo-oo-oo-oo-oo"""
-#     board = Board(board_string=board_string)
-#     move_candidates = get_pawn_move_candidates(board=board, position=(6, 6))
-#     result = tuple(
-#         validate_move_candidates(board=board, move_candidates=move_candidates)
-#     )
+def test_is_valid_move_pawn_cant_move():
+    # when
+    board_string = f"""oo-bn-bb-oo-oo-bb-oo-oo
+            bk-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-br-oo-wp-wk
+            oo-oo-oo-oo-oo-oo-oo-oo"""
+    board = Board(board_string=board_string)
+    move_candidates = get_pawn_move_candidates(board=board, position=(6, 6))
 
-#     # then
-#     assert result == ()
+    # then
+    assert all(
+        tuple(
+            not is_valid_move(
+                board=board,
+                move=Move(
+                    type=REGULAR_MOVE,
+                    piece_moves=(move_candidate,),
+                    moving_pieces=(board[(6, 6)],),
+                    allows_en_passant=False,
+                    is_capturing_move=False,
+                ),
+            )
+            for move_candidate in move_candidates
+        )
+    )
 
 
-# @pytest.mark.parametrize(
-#     ("board", "from_move", "to_move", "expected"),
-#     [
-#         (
-#             Board(
-#                 board_string=f"""bk-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-bp-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-wp-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-wk""",
-#             ),
-#             (7, 7),
-#             (7, 6),
-#             Board(
-#                 board_string=f"""bk-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-bp-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-wp-oo-oo-oo-wk
-#             oo-oo-oo-oo-oo-oo-oo-oo""",
-#             ),
-#         ),
-#         (
-#             Board(
-#                 board_string=f"""bk-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-bp-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-wp-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-wk""",
-#             ),
-#             (4, 4),
-#             (4, 5),
-#             Board(
-#                 board_string=f"""bk-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-oo
-#             oo-oo-oo-oo-bp-oo-oo-oo
-#             oo-oo-oo-wp-oo-oo-oo-oo
-#             oo-oo-oo-oo-oo-oo-oo-wk""",
-#             ),
-#         ),
-#     ],
-# )
-# def test_make_regular_move(board, from_move, to_move, expected):
-#     # given
-#     regular_move = Move(
-#         type=REGULAR_MOVE,
-#         piece_moves=((from_move, to_move),),
-#         moving_pieces=board[from_move],
-#         is_capturing_move=False,
-#         allows_en_passant=False,
-#     )
+@pytest.mark.parametrize(
+    ("board", "from_move", "to_move", "expected"),
+    [
+        (
+            Board(
+                board_string=f"""bk-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-bp-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-wp-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-wk""",
+            ),
+            (7, 7),
+            (7, 6),
+            Board(
+                board_string=f"""bk-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-bp-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-wp-oo-oo-oo-wk
+            oo-oo-oo-oo-oo-oo-oo-oo""",
+            ),
+        ),
+        (
+            Board(
+                board_string=f"""bk-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-bp-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-wp-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-wk""",
+            ),
+            (4, 4),
+            (4, 5),
+            Board(
+                board_string=f"""bk-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-bp-oo-oo-oo
+            oo-oo-oo-wp-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-wk""",
+            ),
+        ),
+    ],
+)
+def test_make_regular_move(board, from_move, to_move, expected):
+    # given
+    from utahchess.regular_move import REGULAR_MOVE
 
-#     # when
-#     result = make_move(board=board, move=regular_move)
+    regular_move = Move(
+        type=REGULAR_MOVE,
+        piece_moves=((from_move, to_move),),
+        moving_pieces=board[from_move],
+        is_capturing_move=False,
+        allows_en_passant=False,
+    )
 
-#     # then
-#     assert result == expected
+    # when
+    result = make_move(board=board, move=regular_move)
+
+    # then
+    assert result == expected

--- a/tests/test_regular_move.py
+++ b/tests/test_regular_move.py
@@ -1,5 +1,3 @@
-import pytest
-
 from utahchess.board import Board
 from utahchess.regular_move import get_regular_moves
 

--- a/tests/test_regular_move.py
+++ b/tests/test_regular_move.py
@@ -1,0 +1,9 @@
+from utahchess.board import Board
+from utahchess.regular_move import get_regular_moves
+
+
+def test_get_regular_moves():
+    # when and then
+    board = Board()
+    get_regular_moves(board=board, current_player="black")
+    get_regular_moves(board=board, current_player="white")

--- a/tests/test_regular_move.py
+++ b/tests/test_regular_move.py
@@ -1,9 +1,28 @@
+import pytest
+
 from utahchess.board import Board
 from utahchess.regular_move import get_regular_moves
 
 
-def test_get_regular_moves():
+def test_get_regular_moves(
+    initial_board_with_only_rooks,
+    initial_board_with_only_bishops,
+    initial_board_with_only_queens,
+    initial_board_with_only_kings,
+):
     # when and then
     board = Board()
-    get_regular_moves(board=board, current_player="black")
-    get_regular_moves(board=board, current_player="white")
+    for current_player in ("white", "black"):
+        get_regular_moves(board=board, current_player=current_player)
+        get_regular_moves(
+            board=initial_board_with_only_rooks, current_player=current_player
+        )
+        get_regular_moves(
+            board=initial_board_with_only_bishops, current_player=current_player
+        )
+        get_regular_moves(
+            board=initial_board_with_only_queens, current_player=current_player
+        )
+        get_regular_moves(
+            board=initial_board_with_only_kings, current_player=current_player
+        )

--- a/utahchess/legal_moves.py
+++ b/utahchess/legal_moves.py
@@ -9,7 +9,8 @@ from utahchess.board import Board
 from utahchess.castling import LONG_CASTLING, SHORT_CASTLING, get_castling_moves
 from utahchess.en_passant import EN_PASSANT_MOVE, get_en_passant_moves
 from utahchess.move import Move
-from utahchess.move_validation import get_legal_regular_moves, is_check, is_checkmate
+from utahchess.move_validation import is_check, is_checkmate
+from utahchess.regular_move import get_regular_moves
 
 FILE_POSSIBILITIES = "abcdefgh"
 RANK_POSSIBILITIES = "87654321"
@@ -97,7 +98,7 @@ def _get_ambiguous_algebraic_notation_mapping(
 def _get_all_legal_moves(
     board: Board, current_player: str, last_move: Optional[Move]
 ) -> Generator[Move, None, None]:
-    regular_moves = get_legal_regular_moves(board=board, current_player=current_player)
+    regular_moves = get_regular_moves(board=board, current_player=current_player)
     castling_moves = get_castling_moves(board=board, current_player=current_player)
     en_passant_moves = get_en_passant_moves(board=board, last_move=last_move)
     return chain(regular_moves, en_passant_moves, castling_moves)  # type: ignore

--- a/utahchess/move_validation.py
+++ b/utahchess/move_validation.py
@@ -1,22 +1,8 @@
 from __future__ import annotations
 
-from typing import Generator
-
 from utahchess.board import Board
 from utahchess.move import Move
 from utahchess.move_candidates import get_all_move_candidates
-from utahchess.piece import Piece
-
-REGULAR_MOVE = "Regular Move"
-
-
-def get_legal_regular_moves(
-    board: Board, current_player: str
-) -> Generator[Move, None, None]:
-    all_move_candidates = get_all_move_candidates(
-        board=board, current_player=current_player
-    )
-    return validate_move_candidates(board=board, move_candidates=all_move_candidates)
 
 
 def is_check(board: Board, current_player: str) -> bool:
@@ -38,15 +24,6 @@ def is_check(board: Board, current_player: str) -> bool:
     ]
 
     return current_player_king_position in all_possible_enemy_destinations
-
-
-def find_current_players_king_position(
-    board: Board, current_player: str
-) -> tuple[int, int]:
-    for piece in board.all_pieces():
-        if piece.piece_type == "King" and piece.color == current_player:
-            return piece.position
-    raise Exception(f"No King found for {current_player}")
 
 
 def is_checkmate(board: Board, current_player: str) -> bool:
@@ -78,49 +55,10 @@ def is_valid_move(board: Board, move: Move) -> bool:
     return not is_check(board=board_after_move, current_player=current_player)
 
 
-def validate_move_candidates(
-    board: Board,
-    move_candidates: Generator[tuple[tuple[int, int], tuple[int, int]], None, None],
-) -> Generator[Move, None, None]:
-    """Filter move candidates based on whether they leave king unprotected."""
-
-    for move_candidate in move_candidates:
-        from_position, to_position = move_candidate
-        board_after_move = board.move_piece(
-            from_position=from_position, to_position=to_position
-        )
-        from_piece = board[from_position]
-        if from_piece is None:
-            raise Exception(
-                f"Piece at position {from_position} is None when the position should be occupied."
-            )
-
-        current_player = from_piece.color
-        destination = board[to_position]
-        is_capturing_move = False if destination is None else True
-        if not is_check(board=board_after_move, current_player=current_player):
-            yield Move(
-                type=REGULAR_MOVE,
-                piece_moves=(move_candidate,),
-                moving_pieces=(from_piece,),
-                is_capturing_move=is_capturing_move,
-                allows_en_passant=_set_allows_en_passant_flag(
-                    piece_moves=(move_candidate,), moving_pieces=(from_piece,)
-                ),
-            )
-
-
-def _set_allows_en_passant_flag(
-    moving_pieces: tuple[Piece],
-    piece_moves: tuple[tuple[tuple[int, int], tuple[int, int]]],
-) -> bool:
-    return (
-        moving_pieces[0].piece_type == "Pawn"
-        and abs(_get_distance_moved_in_y_direction(piece_moves[0])) == 2
-    )
-
-
-def _get_distance_moved_in_y_direction(
-    piece_move: tuple[tuple[int, int], tuple[int, int]]
-) -> int:
-    return piece_move[1][1] - piece_move[0][1]
+def find_current_players_king_position(
+    board: Board, current_player: str
+) -> tuple[int, int]:
+    for piece in board.all_pieces():
+        if piece.piece_type == "King" and piece.color == current_player:
+            return piece.position
+    raise Exception(f"No King found for {current_player}")

--- a/utahchess/regular_move.py
+++ b/utahchess/regular_move.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Generator
+
+from utahchess.board import Board
+from utahchess.move import Move
+from utahchess.move_candidates import get_all_move_candidates
+from utahchess.move_validation import is_valid_move
+from utahchess.piece import Piece
+
+REGULAR_MOVE = "Regular Move"
+
+
+def get_regular_moves(board: Board, current_player: str) -> Generator[Move, None, None]:
+    for move_candidate in get_all_move_candidates(
+        board=board, current_player=current_player
+    ):
+        from_position, to_position = move_candidate
+        from_piece = board[from_position]
+        if from_piece is None:
+            raise Exception(f"Piece at {from_position} unexpectedly None.")
+        potential_move = Move(
+            type=REGULAR_MOVE,
+            piece_moves=(move_candidate,),
+            moving_pieces=(from_piece,),
+            is_capturing_move=False if board[to_position] is None else True,
+            allows_en_passant=_set_allows_en_passant_flag(
+                piece_moves=(move_candidate,), moving_pieces=(from_piece,)
+            ),
+        )
+        if is_valid_move(board=board, move=potential_move):
+            yield potential_move
+
+
+def _set_allows_en_passant_flag(
+    moving_pieces: tuple[Piece],
+    piece_moves: tuple[tuple[tuple[int, int], tuple[int, int]]],
+) -> bool:
+    return (
+        moving_pieces[0].piece_type == "Pawn"
+        and abs(_get_distance_moved_in_y_direction(piece_moves[0])) == 2
+    )
+
+
+def _get_distance_moved_in_y_direction(
+    piece_move: tuple[tuple[int, int], tuple[int, int]]
+) -> int:
+    return piece_move[1][1] - piece_move[0][1]


### PR DESCRIPTION
This PR

- splits the generation of regular moves from the `move_validation` module and moves it to a separate module called `regular_move`
- removes the function to validate move candidates in batches. Instead the function `is_valid_move` (which was already introduced to validate en passant moves in [this PR](https://github.com/PomboLutador/utahchess/pull/4)) is promoted to handle validation of move candidates

Note that since the new `get_regular_moves` function is a relatively simple amalgamation of already tested functions (i.e. `get_all_move_candidates` and `is_valid_move`) a simple smoke test was used to test it.