### PR TITLE
Cut useless dependencies

### DIFF
--- a/analyses/alpha_beta_performance_increase/analysis.py
+++ b/analyses/alpha_beta_performance_increase/analysis.py
@@ -5,10 +5,8 @@ from functools import partial
 from os import walk
 from typing import Generator, Sequence
 
-import numpy as np
-
 from utahchess.board import Board
-from utahchess.minimax import create_children_from_parent, get_node_value, minimax, Node
+from utahchess.minimax import Node, create_children_from_parent, get_node_value, minimax
 
 
 def generate_dataset(
@@ -30,14 +28,20 @@ def run_experiment(
     found_values = []
     for board in dataset:
 
-        parent_node = Node(name="initial_node", parent=None, board=board, last_move=None, player="white")
+        parent_node = Node(
+            name="initial_node",
+            parent=None,
+            board=board,
+            last_move=None,
+            player="white",
+        )
         suggested_node, value = minimax(
             parent_node=parent_node,
             value_function=get_node_value,
             get_children=partial(create_children_from_parent, ordered=order),
             depth=depth,
-            alpha=-np.inf,
-            beta=np.inf,
+            alpha=-float("inf"),
+            beta=float("inf"),
             maximizing_player=True,
             prune=prune,
         )

--- a/analyses/alpha_beta_performance_increase/analysis.py
+++ b/analyses/alpha_beta_performance_increase/analysis.py
@@ -6,10 +6,9 @@ from os import walk
 from typing import Generator, Sequence
 
 import numpy as np
-from anytree import Node  # type: ignore
 
 from utahchess.board import Board
-from utahchess.minimax import create_children_from_parent, get_node_value, minimax
+from utahchess.minimax import create_children_from_parent, get_node_value, minimax, Node
 
 
 def generate_dataset(
@@ -31,7 +30,7 @@ def run_experiment(
     found_values = []
     for board in dataset:
 
-        parent_node = Node("initial_node", board=board, last_move=None, player="white")
+        parent_node = Node(name="initial_node", parent=None, board=board, last_move=None, player="white")
         suggested_node, value = minimax(
             parent_node=parent_node,
             value_function=get_node_value,

--- a/analyses/alpha_beta_performance_increase/create_dataset.py
+++ b/analyses/alpha_beta_performance_increase/create_dataset.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
             print(f"Saving board {count}")
         with open(
             f"analyses"
-            f"/alpha_beta_performance_increase/board_strings/aaa_board_{count}.txt",
+            f"/alpha_beta_performance_increase/board_strings/board_{count}.txt",
             "w",
         ) as file:
             file.write(board.to_string())

--- a/analyses/alpha_beta_performance_increase/create_dataset.py
+++ b/analyses/alpha_beta_performance_increase/create_dataset.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
+import random
 from itertools import product
 from typing import Type
-
-import numpy as np
 
 from utahchess.board import Board
 from utahchess.move_validation import is_check, is_checkmate
@@ -18,12 +17,12 @@ IMBALANCE_RANGE_HIGH = 0.7
 
 
 def sample_n_positions(n: int) -> list[tuple[int, int]]:
-    np.random.shuffle(POSSIBLE_INDICES)
+    random.shuffle(POSSIBLE_INDICES)
     return list(ALL_POSITIONS[i] for i in POSSIBLE_INDICES[:n])
 
 
 def sample_random_board(n_pieces: int) -> Board:
-    board_pieces = []
+    board_pieces: list[Piece] = []
     positions_to_fill = sample_n_positions(n=n_pieces)
     # place two kings
     board_pieces.append(
@@ -43,7 +42,7 @@ def sample_random_board(n_pieces: int) -> Board:
 
     pieces_left = n_pieces - 2
     white_number_of_pieces = int(
-        np.random.uniform(IMBALANCE_RANGE_LOW, IMBALANCE_RANGE_HIGH) * pieces_left
+        random.uniform(IMBALANCE_RANGE_LOW, IMBALANCE_RANGE_HIGH) * pieces_left
     )
     black_number_of_pieces = pieces_left - white_number_of_pieces
 
@@ -63,9 +62,9 @@ def sample_random_board(n_pieces: int) -> Board:
             Queen,
         )
         for _ in range(number_of_pieces):
-            class_to_instantiate = np.random.choice(valid_choices)  # type: ignore
+            class_to_instantiate = random.choice(valid_choices)  # type: ignore
             board_pieces.append(
-                class_to_instantiate(
+                class_to_instantiate(  # type: ignore
                     position=positions_to_fill.pop(),
                     color=color,
                     is_in_start_position=False,
@@ -128,14 +127,14 @@ if __name__ == "__main__":
     NUM_BOARDS = 1000
     count = 0
     while count < NUM_BOARDS:
-        num_pieces = int(np.random.uniform(3, 20))
+        num_pieces = int(random.uniform(3, 20))
         board = sample_random_board(n_pieces=num_pieces)
         count += 1
         if count % 10 == 0:
             print(f"Saving board {count}")
         with open(
             f"analyses"
-            f"/alpha_beta_performance_increase/board_strings/board_{count}.txt",
+            f"/alpha_beta_performance_increase/board_strings/aaa_board_{count}.txt",
             "w",
         ) as file:
             file.write(board.to_string())

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ iniconfig==1.1.1
 isort==5.9.3
 mypy==0.910
 mypy-extensions==0.4.3
-numpy==1.21.3
 packaging==21.2
 pathspec==0.9.0
 platformdirs==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ toml==0.10.2
 tomli==1.2.1
 typing-extensions==3.10.0.2
 wincertstore==0.2
-anytree==2.8.0
 atomicwrites==1.4.0
 attrs==21.2.0
 black==21.9b0

--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -2,11 +2,11 @@ from functools import partial
 
 import numpy as np
 import pytest
-from anytree import Node  # type: ignore
 
 from utahchess.board import Board
 from utahchess.legal_moves import get_algebraic_notation_mapping, make_move
 from utahchess.minimax import (
+    Node,
     create_children_from_parent,
     get_board_value,
     get_node_value,
@@ -113,7 +113,9 @@ def test_minimax_finds_checkmate_in_fools_mate(depth, ordered):
             wp-wp-wp-wp-wp-oo-oo-wp
             wr-wn-wb-wq-wk-wb-wn-wr"""
     )
-    parent_node = Node(name="parent", board=board, last_move=None, player="black")
+    parent_node = Node(
+        name="parent", parent=None, board=board, last_move=None, player="black"
+    )
 
     # when
     resulting_node, resulting_value = minimax(
@@ -134,7 +136,7 @@ def test_minimax_finds_checkmate_in_fools_mate(depth, ordered):
 def test_minimax_with_dummy_game():
     # given
 
-    parent_node = Node(name="parent", value=3, depth=0)
+    parent_node = Node(name="parent", parent=None, value=3, depth=0)
 
     def children_nodes_function(parent_node):
         return [

--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -1,6 +1,5 @@
 from functools import partial
 
-import numpy as np
 import pytest
 
 from utahchess.board import Board
@@ -66,7 +65,7 @@ def test_get_board_value_is_infinite_when_in_checkmate():
 
     # then
     assert is_checkmate(board=board, current_player="white")
-    assert result_black == np.inf
+    assert result_black == float("inf")
     assert result_black == -result_white
 
 
@@ -123,14 +122,14 @@ def test_minimax_finds_checkmate_in_fools_mate(depth, ordered):
         value_function=get_node_value,
         get_children=children_function,
         depth=depth,
-        alpha=-np.inf,
-        beta=np.inf,
+        alpha=-float("inf"),
+        beta=float("inf"),
         maximizing_player=True,
     )
 
     # then
     assert resulting_node.name == "Qh4#"
-    assert resulting_value == np.inf
+    assert resulting_value == float("inf")
 
 
 def test_minimax_with_dummy_game():
@@ -159,8 +158,8 @@ def test_minimax_with_dummy_game():
         get_children=children_nodes_function,
         depth=3,
         maximizing_player=True,
-        alpha=-np.inf,
-        beta=np.inf,
+        alpha=-float("inf"),
+        beta=float("inf"),
     )
 
     # then

--- a/utahchess/minimax.py
+++ b/utahchess/minimax.py
@@ -4,8 +4,6 @@ from collections import OrderedDict
 from itertools import product
 from typing import Any, Callable, Generator, Optional
 
-import numpy as np
-
 from utahchess.board import Board
 from utahchess.legal_moves import get_algebraic_notation_mapping, make_move
 from utahchess.move import Move
@@ -16,7 +14,7 @@ BISHOP_VALUE = 3
 KNIGHT_VALUE = 3
 ROOK_VALUE = 5
 QUEEN_VALUE = 9
-CHECKMATE_VALUE = np.inf
+CHECKMATE_VALUE = float("inf")
 
 CENTER_OF_BOARD_POSITIONS = tuple(product((2, 3, 4, 5), (2, 3, 4, 5)))
 CENTER_OF_BOARD_VALUE = 0.25
@@ -59,7 +57,7 @@ def minimax(
 
     best_move: Any = None
     if maximizing_player:
-        best_value = -np.inf
+        best_value = -float("inf")
         for child_node in get_children(parent_node=parent_node):
             _, eval = minimax(
                 parent_node=child_node,
@@ -80,7 +78,7 @@ def minimax(
                     break
 
     else:
-        best_value = +np.inf
+        best_value = +float("inf")
         for child_node in get_children(parent_node=parent_node):
             _, eval = minimax(
                 parent_node=child_node,
@@ -235,8 +233,8 @@ if __name__ == "__main__":
         value_function=get_node_value,
         get_children=create_children_from_parent,
         depth=4,
-        alpha=-np.inf,
-        beta=np.inf,
+        alpha=-float("inf"),
+        beta=float("inf"),
         maximizing_player=True,
     )
     print(suggested_node, value)


### PR DESCRIPTION
This PR

- cuts the dependency to `anytree` by implementing a simple `Node` class used in the minimax algorithm implementation
- cuts the dependency to `numpy` by making use of python3's built-in `random` module and built-in implementation of `inf` and `-inf`
- fixes the following issue: https://github.com/PomboLutador/utahchess/issues/6 and the first half of this issue: https://github.com/PomboLutador/utahchess/issues/15