### PR TITLE
Update readme and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /utahchess/cython_extension/*
 *.cfg
 /env*
+*egg-info

--- a/README.MD
+++ b/README.MD
@@ -16,7 +16,7 @@ Formatting is kept with `isort` and `black` using the command `isort --skip env 
 Static type checking is done with `mypy` (with command `mypy -p utahchess` or `mypy .` from project root).
 
 
-Linting is done with `flake8 (v4.0.1)` with command `flake8 --extend-ignore=F541,E203 --max-line-length=88`.
+Linting is done with `flake8` with command `flake8 --extend-ignore=F541,E203 --max-line-length=88`.
 
 ## Tests
 pytest is used for the test suite. Execute `pytest` from project root.

--- a/README.MD
+++ b/README.MD
@@ -8,11 +8,15 @@
 Run file `gui/pygame/pygame_gui.py`
 
 ## Formatting & Type Checking
-Formatting is kept with `isort` and `black` using the command `isort --skip env/* . && black --exclude env .` 
-(assuming a `virtualenv` is installed in `env`). `pyproject.toml` contains
-the settings for `isort` to be compatible with `black`.
+Formatting is kept with `isort` and `black` using the command `isort --skip env . && black --exclude env .` 
+(assuming a `virtualenv` is installed in `env`). 
+`pyproject.toml` contains the settings for `isort` to be compatible with `black`.
+
+
 Static type checking is done with `mypy` (with command `mypy -p utahchess` or `mypy .` from project root).
+
+
 Linting is done with `flake8 (v4.0.1)` with command `flake8 --extend-ignore=F541,E203 --max-line-length=88`.
 
 ## Tests
-pyTest is used for the test suite. Execute `pytest` from project root.
+pytest is used for the test suite. Execute `pytest` from project root.


### PR DESCRIPTION
This PR

- updates `README.md` to contain the correct command to format the repo without formatting an environment in `/env`
- updates `.gitignore` to ignore files from eggs coming from editable installs of the `utahchess` package