### PR TITLE
Consolidate algebraic notation

### DIFF
--- a/tests/test_algebraic_notation.py
+++ b/tests/test_algebraic_notation.py
@@ -1,0 +1,224 @@
+import pytest
+
+from utahchess.algebraic_notation import get_algebraic_identifer
+from utahchess.board import Board
+from utahchess.castling import get_castling_moves
+from utahchess.move import EN_PASSANT_MOVE, REGULAR_MOVE, Move
+
+
+def test_get_algebraic_identifer_with_regular_move():
+    # given
+    board = Board()
+    move = Move(
+        type=REGULAR_MOVE,
+        piece_moves=(((1, 1), (1, 3)),),
+        moving_pieces=(board[(1, 1)],),
+        is_capturing_move=False,
+        allows_en_passant=True,
+    )
+
+    # when
+    result = get_algebraic_identifer(move=move, board=board)
+
+    # then
+    assert result == "b5"
+
+
+def test_get_algebraic_identifier_with_checkmate():
+    # given
+    board = Board(
+        board_string=(
+            f"""br-bn-bb-bq-bk-bb-bn-br
+            bp-bp-bp-bp-oo-bp-bp-bp
+            oo-oo-oo-oo-bp-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-wp-oo
+            oo-oo-oo-oo-oo-wp-oo-oo
+            wp-wp-wp-wp-wp-oo-oo-wp
+            wr-wn-wb-wq-wk-wb-wn-wr"""
+        )
+    )
+    move = Move(
+        type=REGULAR_MOVE,
+        piece_moves=(((3, 0), (7, 4)),),
+        moving_pieces=(board[(3, 0)],),
+        is_capturing_move=False,
+        allows_en_passant=False,
+    )
+
+    # when
+    result = get_algebraic_identifer(move=move, board=board)
+
+    # then
+    assert result == "Qh4#"
+
+
+def test_get_algebraic_identifier_with_check():
+    # given
+    board = Board(
+        board_string=(
+            f"""br-bn-bb-bq-bk-bb-bn-br
+            bp-bp-bp-bp-oo-bp-bp-bp
+            oo-oo-oo-oo-bp-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-wp-oo
+            oo-oo-oo-wp-oo-wp-oo-oo
+            wp-wp-wp-oo-wp-oo-oo-wp
+            wr-wn-wb-wq-wk-wb-wn-wr"""
+        )
+    )
+    move = Move(
+        type=REGULAR_MOVE,
+        piece_moves=(((3, 0), (7, 4)),),
+        moving_pieces=(board[(3, 0)],),
+        is_capturing_move=False,
+        allows_en_passant=False,
+    )
+
+    # when
+    result = get_algebraic_identifer(move=move, board=board)
+
+    # then
+    assert result == "Qh4+"
+
+
+def test_get_algebraic_identifier_with_rank_and_file():
+    # given
+    board = Board(
+        board_string=(
+            f"""oo-bk-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-wk-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            wr-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            bn-oo-oo-oo-oo-oo-oo-wr"""
+        )
+    )
+    move_1 = Move(
+        type=REGULAR_MOVE,
+        piece_moves=(((0, 5), (0, 7)),),
+        moving_pieces=(board[(0, 5)],),
+        is_capturing_move=True,
+        allows_en_passant=False,
+    )
+    move_2 = Move(
+        type=REGULAR_MOVE,
+        piece_moves=(((7, 7), (0, 7)),),
+        moving_pieces=(board[(7, 7)],),
+        is_capturing_move=True,
+        allows_en_passant=False,
+    )
+
+    # when
+    identifier_1_without_rank_or_file = get_algebraic_identifer(
+        move=move_1, board=board
+    )
+    identifier_2_without_rank_or_file = get_algebraic_identifer(
+        move=move_2, board=board
+    )
+    identifier_1 = get_algebraic_identifer(move=move_1, board=board, file="a")
+    identifier_2 = get_algebraic_identifer(move=move_2, board=board, file="h")
+
+    # then
+    assert identifier_1_without_rank_or_file == identifier_2_without_rank_or_file
+    assert identifier_1 == "Raxa1"
+    assert identifier_2 == "Rhxa1"
+
+
+def test_get_algebraic_identifer_with_en_passant_move():
+    # given
+    board = Board(
+        board_string=f"""oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-bk-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            wp-bp-wp-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-wk-oo-oo-oo"""
+    )
+    move = Move(
+        type=EN_PASSANT_MOVE,
+        piece_moves=(((2, 3), (1, 2)),),
+        moving_pieces=(board[2, 3],),
+        pieces_to_delete=((1, 3),),
+        is_capturing_move=True,
+        allows_en_passant=False,
+    )
+
+    # when
+    result = get_algebraic_identifer(move=move, board=board)
+
+    # then
+    assert result == "xb6 e.p."
+
+
+@pytest.mark.parametrize(
+    ("board_string", "current_player", "expected"),
+    [
+        (
+            f"""br-oo-oo-oo-bk-bb-bn-br
+            bp-bp-bp-bp-bq-bp-bp-bp
+            oo-oo-oo-oo-bp-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-wp-oo
+            oo-oo-oo-oo-oo-wp-oo-oo
+            wp-wp-wp-wp-wp-oo-oo-wp
+            wr-wn-wb-wq-wn-wb-wn-wr""",
+            "black",
+            "O-O-O",
+        ),
+        (
+            f"""br-bn-bb-oo-bk-oo-oo-br
+            bp-bp-bp-bp-bq-bp-bp-bp
+            oo-oo-oo-oo-bp-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-wp-oo
+            oo-oo-oo-oo-oo-wp-oo-oo
+            wp-wp-wp-wp-wp-oo-oo-wp
+            wr-wn-wb-wq-wk-wb-wn-wr""",
+            "black",
+            "O-O",
+        ),
+        (
+            f"""br-bn-bb-oo-bk-bb-bn-br
+            bp-bp-bp-bp-bq-bp-bp-bp
+            oo-oo-oo-oo-bp-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-wp-oo
+            oo-oo-oo-oo-oo-wp-oo-oo
+            wp-wp-wp-wp-wp-oo-oo-wp
+            wr-oo-oo-oo-wk-wb-wn-wr""",
+            "white",
+            "O-O-O",
+        ),
+        (
+            f"""br-bn-bb-oo-bk-bb-bn-br
+            bp-bp-bp-bp-bq-bp-bp-bp
+            oo-oo-oo-oo-bp-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-wp-oo
+            oo-oo-oo-oo-oo-wp-oo-oo
+            wp-wp-wp-wp-wp-oo-oo-wp
+            wr-wn-wb-wq-wk-oo-oo-wr""",
+            "white",
+            "O-O",
+        ),
+    ],
+)
+def test_get_algebraic_identifer_with_castling_move(
+    board_string, current_player, expected
+):
+    # given
+    board = Board(board_string=board_string)
+    castling_move = tuple(
+        get_castling_moves(board=board, current_player=current_player)
+    )[0]
+
+    # when
+    result = get_algebraic_identifer(move=castling_move, board=board)
+
+    # then
+    assert expected == result

--- a/tests/test_legal_moves.py
+++ b/tests/test_legal_moves.py
@@ -1,7 +1,7 @@
 import pytest
 
 from utahchess.board import Board
-from utahchess.legal_moves import get_algebraic_notation_mapping, is_stalemate
+from utahchess.legal_moves import get_move_per_algebraic_identifier, is_stalemate
 from utahchess.move import REGULAR_MOVE, Move, make_move
 
 
@@ -143,7 +143,7 @@ from utahchess.move import REGULAR_MOVE, Move, make_move
         ),
     ],
 )
-def test_get_algebraic_notation_mapping(
+def test_get_move_per_algebraic_identifier(
     board_string, expected_legal_moves_in_algebraic_notation, current_player
 ):
     # given
@@ -151,7 +151,7 @@ def test_get_algebraic_notation_mapping(
 
     # when
     result = tuple(
-        get_algebraic_notation_mapping(
+        get_move_per_algebraic_identifier(
             board=board, current_player=current_player, last_move=None
         ).keys()
     )
@@ -219,7 +219,7 @@ def test_get_algebraic_notation_mapping(
         ),
     ],
 )
-def test_get_algebraic_notation_mapping_with_last_move_for_en_passant(
+def test_get_move_per_algebraic_identifier_with_last_move_for_en_passant(
     board_string,
     expected_legal_moves_in_algebraic_notation,
     current_player,
@@ -238,7 +238,7 @@ def test_get_algebraic_notation_mapping_with_last_move_for_en_passant(
 
     # when
     result = tuple(
-        get_algebraic_notation_mapping(
+        get_move_per_algebraic_identifier(
             board=board_after_move,
             current_player=current_player,
             last_move=move_to_make,
@@ -263,7 +263,7 @@ def test_is_stalemate():
             oo-wr-oo-oo-oo-oo-oo-wk"""
     )
     black_legal_moves = tuple(
-        get_algebraic_notation_mapping(
+        get_move_per_algebraic_identifier(
             board=board, current_player="black", last_move=None
         ).keys()
     )
@@ -292,7 +292,7 @@ def test_is_not_stalemate():
             oo-wr-oo-oo-oo-oo-oo-wk"""
     )
     black_legal_moves = tuple(
-        get_algebraic_notation_mapping(
+        get_move_per_algebraic_identifier(
             board=board, current_player="black", last_move=None
         ).keys()
     )

--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 
 from utahchess.board import Board
-from utahchess.legal_moves import get_algebraic_notation_mapping
+from utahchess.legal_moves import get_move_per_algebraic_identifier
 from utahchess.minimax import (
     Node,
     create_children_from_parent,
@@ -78,7 +78,7 @@ def test_get_board_value_is_symmetric(current_player, opposite_player):
     # given
     board = Board()
     for move in list(
-        get_algebraic_notation_mapping(
+        get_move_per_algebraic_identifier(
             board=board, current_player=current_player, last_move=None
         ).values()
     ):

--- a/utahchess/algebraic_notation.py
+++ b/utahchess/algebraic_notation.py
@@ -1,36 +1,99 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from utahchess.board import Board
+from utahchess.move import (
+    EN_PASSANT_MOVE,
+    LONG_CASTLING,
+    SHORT_CASTLING,
+    Move,
+    make_move,
+)
+from utahchess.move_validation import is_check, is_checkmate
+from utahchess.utils import x_index_to_file, y_index_to_rank
 
 
-@dataclass(frozen=True)
-class AlgebraicNotation:
-    castling_identifier: str
-    en_passant_identifer: str
-    piece: str
-    destination_tile: str
-    capturing_flag: str
-    check_or_checkmate_flag: str
+def get_algebraic_identifer(move: Move, board: Board, **kwargs):
+    if move.type in (LONG_CASTLING, SHORT_CASTLING):
+        return _get_castling_identifer(move=move)
+    check_or_checkmate_identifer = _get_check_or_checkmate_identifier(
+        board=board,
+        move=move,
+        current_player=move.moving_pieces[0].color,
+    )
+    try:
+        rank = kwargs["rank"]
+    except KeyError:
+        rank = ""
+    try:
+        file = kwargs["file"]
+    except KeyError:
+        file = ""
 
-    def to_string(self) -> str:
-        if self.castling_identifier:
-            return self.castling_identifier
-        return (
-            f"{self.piece}{self.capturing_flag}{self.destination_tile}"
-            f"{self.en_passant_identifer}{self.check_or_checkmate_flag}"
-        )
+    return (
+        f"{_get_moving_piece_signifier(move=move)}{rank}{file}"
+        f"{_get_capturing_flag(move=move)}{_get_destination_tile(move=move)}"
+        f"{_get_en_passant_identifier(move=move)}{check_or_checkmate_identifer}"
+    )
 
-    def __repr__(self) -> str:
-        return self.to_string()
 
-    def to_string_with_file(self, file: str) -> str:
-        return (
-            f"{self.piece}{file}{self.capturing_flag}{self.destination_tile}"
-            f"{self.en_passant_identifer}{self.check_or_checkmate_flag}"
-        )
+def _get_moving_piece_signifier(move: Move) -> str:
+    piece = move.moving_pieces[0]
+    if piece.piece_type == "Pawn":
+        return ""
+    elif piece.piece_type == "King":
+        return "K"
+    elif piece.piece_type == "Bishop":
+        return "B"
+    elif piece.piece_type == "Queen":
+        return "Q"
+    elif piece.piece_type == "Knight":
+        return "N"
+    elif piece.piece_type == "Rook":
+        return "R"
+    raise Exception(f"Unrecognized piece type: {piece.piece_type}")
 
-    def to_string_with_rank(self, rank: str) -> str:
-        return (
-            f"{self.piece}{rank}{self.capturing_flag}{self.destination_tile}"
-            f"{self.en_passant_identifer}{self.check_or_checkmate_flag}"
-        )
+
+def _get_destination_tile(move: Move) -> str:
+    x, y = move.piece_moves[0][1]
+    return f"{x_index_to_file(x=x)}{y_index_to_rank(y=y)}"
+
+
+def _get_capturing_flag(move: Move) -> str:
+    return "x" if move.is_capturing_move else ""
+
+
+def _get_castling_identifer(move: Move) -> str:
+    if move.type == SHORT_CASTLING:
+        return "O-O"
+    elif move.type == LONG_CASTLING:
+        return "O-O-O"
+    else:
+        return ""
+
+
+def _get_en_passant_identifier(move: Move) -> str:
+    if move.type == EN_PASSANT_MOVE:
+        return " e.p."
+    return ""
+
+
+def _get_check_or_checkmate_identifier(
+    board: Board, move: Move, current_player: str
+) -> str:
+
+    if is_checkmate(
+        board=make_move(board=board, move=move),
+        current_player=_get_opposite_player(current_player=current_player),
+    ):
+        return "#"
+    elif is_check(
+        board=make_move(board=board, move=move),
+        current_player=_get_opposite_player(current_player=current_player),
+    ):
+        return "+"
+    else:
+        return ""
+
+
+def _get_opposite_player(current_player: str) -> str:
+    return "black" if current_player == "white" else "white"

--- a/utahchess/chess.py
+++ b/utahchess/chess.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from utahchess.board import Board
-from utahchess.legal_moves import get_algebraic_notation_mapping, is_stalemate
+from utahchess.legal_moves import get_move_per_algebraic_identifier, is_stalemate
 from utahchess.move import Move, make_move
 from utahchess.move_validation import is_checkmate
 
@@ -32,7 +32,7 @@ class ChessGame:
         board = Board()
         current_player = "white"
         turn = 1
-        legal_moves = get_algebraic_notation_mapping(
+        legal_moves = get_move_per_algebraic_identifier(
             board=board, current_player=current_player
         )
         self.current_game_state = GameState(
@@ -60,7 +60,7 @@ class ChessGame:
                     turn=self.current_game_state.turn,
                     current_player=self.current_game_state.current_player,
                 ),
-                legal_moves=get_algebraic_notation_mapping(
+                legal_moves=get_move_per_algebraic_identifier(
                     board=board_after_move,
                     current_player=next_player,
                     last_move=last_move,

--- a/utahchess/minimax.py
+++ b/utahchess/minimax.py
@@ -5,7 +5,7 @@ from itertools import product
 from typing import Any, Callable, Generator, Optional
 
 from utahchess.board import Board
-from utahchess.legal_moves import get_algebraic_notation_mapping
+from utahchess.legal_moves import get_move_per_algebraic_identifier
 from utahchess.move import Move, make_move
 from utahchess.move_validation import is_checkmate
 
@@ -143,7 +143,7 @@ def create_children_from_parent(
                 player=_get_enemy_color(friendly_color=parent_player),
             )
             for algebraic_identifier, legal_move in _order_moves_by_potential(
-                get_algebraic_notation_mapping(
+                get_move_per_algebraic_identifier(
                     board=parent_board,
                     current_player=parent_player,
                     last_move=parent_last_move,
@@ -159,7 +159,7 @@ def create_children_from_parent(
                 last_move=legal_move,
                 player=_get_enemy_color(friendly_color=parent_player),
             )
-            for algebraic_identifier, legal_move in get_algebraic_notation_mapping(
+            for algebraic_identifier, legal_move in get_move_per_algebraic_identifier(
                 board=parent_board,
                 current_player=parent_player,
                 last_move=parent_last_move,


### PR DESCRIPTION
This PR 

- gets rid of the `AlgebraicNotation` class and removes it with a function `get_algebraic_identifer`
- moves the calculation of the algebraic identifier out of `legal_moves.py` and into `algebraic_identifier.py`
- simplifies `legal_moves.py`
- implements a large part of https://github.com/PomboLutador/utahchess/issues/17