### PR TITLE
Check all move types when computing is_checkmate

### DIFF
--- a/analyses/alpha_beta_performance_increase/create_dataset.py
+++ b/analyses/alpha_beta_performance_increase/create_dataset.py
@@ -5,7 +5,8 @@ from itertools import product
 from typing import Type
 
 from utahchess.board import Board
-from utahchess.move_validation import is_check, is_checkmate
+from utahchess.legal_moves import is_checkmate
+from utahchess.move_validation import is_check
 from utahchess.piece import Bishop, King, Knight, Pawn, Piece, Queen, Rook
 
 ALL_POSITIONS = tuple(product((0, 1, 2, 3, 4, 5, 6, 7), (0, 1, 2, 3, 4, 5, 6, 7)))

--- a/analyses/alpha_beta_performance_increase/create_dataset.py
+++ b/analyses/alpha_beta_performance_increase/create_dataset.py
@@ -113,9 +113,9 @@ def sample_random_board(n_pieces: int) -> Board:
 
     board = Board(pieces=board_pieces)
 
-    if is_checkmate(board=board, current_player="black") or is_checkmate(
-        board=board, current_player="white"
-    ):
+    if is_checkmate(
+        board=board, current_player="black", last_move=None
+    ) or is_checkmate(board=board, current_player="white", last_move=None):
         return sample_random_board(n_pieces=n_pieces)
     if is_check(board=board, current_player="black") or is_check(
         board=board, current_player="white"

--- a/gui/pygame/draw_current_game_state.py
+++ b/gui/pygame/draw_current_game_state.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 import pygame
 
 from gui.constants import (
@@ -19,6 +21,7 @@ from gui.piece_to_assetname import piece_to_assetname
 from gui.pygame.click_handler import get_pixel_coordinates_from_integer_coordinates
 from utahchess.board import Board
 from utahchess.legal_moves import is_checkmate
+from utahchess.move import Move
 
 
 def draw_pieces(screen: pygame.Surface, board: Board):
@@ -59,9 +62,11 @@ def notify_checkmate(
     player_in_checkmate: str,
     winning_player: str,
     font: pygame.font.Font,
+    last_move: Optional[Move],
 ):
-
-    if is_checkmate(board=board, current_player=player_in_checkmate):
+    if is_checkmate(
+        board=board, current_player=player_in_checkmate, last_move=last_move
+    ):
         text_rect = font.render(
             f"{player_in_checkmate} is in checkmate - {winning_player} wins!",
             True,

--- a/gui/pygame/draw_current_game_state.py
+++ b/gui/pygame/draw_current_game_state.py
@@ -18,7 +18,7 @@ from gui.constants import (
 from gui.piece_to_assetname import piece_to_assetname
 from gui.pygame.click_handler import get_pixel_coordinates_from_integer_coordinates
 from utahchess.board import Board
-from utahchess.move_validation import is_checkmate
+from utahchess.legal_moves import is_checkmate
 
 
 def draw_pieces(screen: pygame.Surface, board: Board):

--- a/gui/pygame/pygame_gui.py
+++ b/gui/pygame/pygame_gui.py
@@ -105,6 +105,7 @@ class PygameGUI:
                 player_in_checkmate=self.get_current_player(),
                 winning_player=self.get_opposite_player(),
                 font=self.font,
+                last_move=self.game.current_game_state.last_move,
             )
         draw_rank_and_file(screen=self.screen, font=self.font)
 

--- a/tests/test_algebraic_notation.py
+++ b/tests/test_algebraic_notation.py
@@ -47,7 +47,7 @@ def test_get_algebraic_identifier_with_checkmate():
     )
 
     # when
-    result = get_algebraic_identifer(move=move, board=board)
+    result = get_algebraic_identifer(move=move, board=board, check_or_checkmate="#")
 
     # then
     assert result == "Qh4#"
@@ -76,7 +76,7 @@ def test_get_algebraic_identifier_with_check():
     )
 
     # when
-    result = get_algebraic_identifer(move=move, board=board)
+    result = get_algebraic_identifer(move=move, board=board, check_or_checkmate="+")
 
     # then
     assert result == "Qh4+"

--- a/tests/test_legal_moves.py
+++ b/tests/test_legal_moves.py
@@ -1,7 +1,7 @@
 import pytest
 
 from utahchess.board import Board
-from utahchess.legal_moves import get_move_per_algebraic_identifier
+from utahchess.legal_moves import get_move_per_algebraic_identifier, is_checkmate
 from utahchess.move import REGULAR_MOVE, Move, make_move
 
 
@@ -248,3 +248,67 @@ def test_get_move_per_algebraic_identifier_with_last_move_for_en_passant(
     # then
     assert len(result) == len(expected_legal_moves_in_algebraic_notation)
     assert set(expected_legal_moves_in_algebraic_notation) == set(result)
+
+
+def test_is_checkmate_fools_mate():
+    # when
+    board_string = f"""br-bn-bb-oo-bk-bb-bn-br
+            bp-bp-bp-bp-oo-bp-bp-bp
+            oo-oo-oo-oo-bp-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-wp-bq
+            oo-oo-oo-oo-oo-wp-oo-oo
+            wp-wp-wp-wp-wp-oo-oo-wp
+            wr-wn-wb-wq-wk-wb-wn-wr"""
+    board = Board(board_string=board_string)
+
+    # then
+    assert is_checkmate(board=board, current_player="white")
+
+
+def test_is_checkmate_friendly_piece_can_save_king():
+    # when
+    board_string = f"""br-oo-wq-bq-bk-bb-oo-br
+            bp-bp-oo-oo-oo-oo-oo-oo
+            bb-oo-oo-oo-oo-bp-oo-oo
+            wp-oo-wb-oo-oo-oo-oo-wb
+            oo-oo-oo-oo-oo-oo-oo-oo
+            wn-oo-oo-oo-oo-oo-oo-oo
+            oo-wp-wk-oo-oo-oo-wp-oo
+            oo-wr-oo-bn-oo-oo-wn-wr"""
+    board = Board(board_string=board_string)
+
+    # then
+    assert not is_checkmate(board=board, current_player="black")
+
+
+def test_is_checkmate_friendly_piece_can_save_king_two():
+    # when
+    board_string = f"""br-oo-oo-oo-oo-bb-oo-br
+            bp-bp-oo-bb-oo-oo-bp-bp
+            bn-oo-oo-bp-oo-bk-oo-oo
+            oo-wb-oo-oo-bp-oo-oo-oo
+            oo-oo-wp-oo-wp-wp-bn-oo
+            wp-oo-wp-oo-oo-oo-oo-oo
+            oo-wb-oo-oo-oo-bq-wp-wp
+            wr-wn-oo-oo-oo-wq-wk-wr"""
+    board = Board(board_string=board_string)
+
+    # then
+    assert not is_checkmate(board=board, current_player="white")
+
+
+def test_is_checkmate_another_scenario():
+    # when
+    board_string = f"""br-oo-oo-wq-oo-bk-oo-br
+            oo-oo-oo-oo-bn-oo-bp-oo
+            oo-wb-oo-oo-wp-bp-oo-oo
+            oo-bp-oo-oo-oo-wp-wn-oo
+            bq-wp-oo-oo-wp-oo-oo-bp
+            bb-oo-wp-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-wn-oo-wb-oo-wn-oo-wr"""
+    board = Board(board_string=board_string)
+
+    # then
+    assert not is_checkmate(board=board, current_player="black")

--- a/tests/test_legal_moves.py
+++ b/tests/test_legal_moves.py
@@ -263,7 +263,7 @@ def test_is_checkmate_fools_mate():
     board = Board(board_string=board_string)
 
     # then
-    assert is_checkmate(board=board, current_player="white")
+    assert is_checkmate(board=board, current_player="white", last_move=None)
 
 
 def test_is_checkmate_friendly_piece_can_save_king():
@@ -279,7 +279,7 @@ def test_is_checkmate_friendly_piece_can_save_king():
     board = Board(board_string=board_string)
 
     # then
-    assert not is_checkmate(board=board, current_player="black")
+    assert not is_checkmate(board=board, current_player="black", last_move=None)
 
 
 def test_is_checkmate_friendly_piece_can_save_king_two():
@@ -295,7 +295,7 @@ def test_is_checkmate_friendly_piece_can_save_king_two():
     board = Board(board_string=board_string)
 
     # then
-    assert not is_checkmate(board=board, current_player="white")
+    assert not is_checkmate(board=board, current_player="white", last_move=None)
 
 
 def test_is_checkmate_another_scenario():
@@ -311,28 +311,29 @@ def test_is_checkmate_another_scenario():
     board = Board(board_string=board_string)
 
     # then
-    assert not is_checkmate(board=board, current_player="black")
+    assert not is_checkmate(board=board, current_player="black", last_move=None)
 
 
 def test_is_checkmate_averted_by_en_passant():
     # given
-    board_string = f"""bk-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-bb
+    board_string = f"""bk-oo-oo-oo-oo-oo-br-bb
             oo-oo-oo-oo-bp-oo-oo-bb
             oo-oo-oo-oo-oo-oo-oo-oo
             oo-oo-oo-wp-oo-oo-oo-oo
             oo-oo-oo-oo-oo-wk-oo-oo
             oo-oo-oo-oo-oo-oo-oo-br
+            oo-oo-oo-oo-oo-oo-oo-oo
             oo-oo-oo-oo-oo-oo-oo-oo"""
     board = Board(board_string=board_string)
     last_move = Move(
         type=REGULAR_MOVE,
-        piece_moves=(((4, 2), (4, 4)),),
-        moving_pieces=board[(4, 2)],
+        piece_moves=(((4, 1), (4, 3)),),
+        moving_pieces=(board[(4, 1)],),
         is_capturing_move=False,
         allows_en_passant=True,
     )
     board = make_move(board=board, move=last_move)
 
     # then
-    assert not is_checkmate(board=board, current_player="white")
+    assert not is_checkmate(board=board, current_player="white", last_move=last_move)
+    assert is_checkmate(board=board, current_player="white", last_move=None)

--- a/tests/test_legal_moves.py
+++ b/tests/test_legal_moves.py
@@ -312,3 +312,27 @@ def test_is_checkmate_another_scenario():
 
     # then
     assert not is_checkmate(board=board, current_player="black")
+
+
+def test_is_checkmate_averted_by_en_passant():
+    # given
+    board_string = f"""bk-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-bb
+            oo-oo-oo-oo-bp-oo-oo-bb
+            oo-oo-oo-oo-oo-oo-oo-oo
+            oo-oo-oo-wp-oo-oo-oo-oo
+            oo-oo-oo-oo-oo-wk-oo-oo
+            oo-oo-oo-oo-oo-oo-oo-br
+            oo-oo-oo-oo-oo-oo-oo-oo"""
+    board = Board(board_string=board_string)
+    last_move = Move(
+        type=REGULAR_MOVE,
+        piece_moves=(((4, 2), (4, 4)),),
+        moving_pieces=board[(4, 2)],
+        is_capturing_move=False,
+        allows_en_passant=True,
+    )
+    board = make_move(board=board, move=last_move)
+
+    # then
+    assert not is_checkmate(board=board, current_player="black")

--- a/tests/test_legal_moves.py
+++ b/tests/test_legal_moves.py
@@ -335,4 +335,4 @@ def test_is_checkmate_averted_by_en_passant():
     board = make_move(board=board, move=last_move)
 
     # then
-    assert not is_checkmate(board=board, current_player="black")
+    assert not is_checkmate(board=board, current_player="white")

--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 
 from utahchess.board import Board
-from utahchess.legal_moves import get_move_per_algebraic_identifier
+from utahchess.legal_moves import get_move_per_algebraic_identifier, is_checkmate
 from utahchess.minimax import (
     Node,
     create_children_from_parent,
@@ -12,7 +12,6 @@ from utahchess.minimax import (
     minimax,
 )
 from utahchess.move import make_move
-from utahchess.move_validation import is_checkmate
 
 
 def test_get_board_value_on_symmetric_board():

--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -19,8 +19,12 @@ def test_get_board_value_on_symmetric_board():
     board = Board()
 
     # when
-    result1 = get_board_value(board=board, player_that_just_made_the_move="white")
-    result2 = get_board_value(board=board, player_that_just_made_the_move="black")
+    result1 = get_board_value(
+        board=board, player_that_just_made_the_move="white", last_move=None
+    )
+    result2 = get_board_value(
+        board=board, player_that_just_made_the_move="black", last_move=None
+    )
 
     # then
     assert result1 == result2
@@ -40,8 +44,12 @@ def test_get_board_value_better_if_middle_is_occupied():
     board2 = Board()
 
     # when
-    result1 = get_board_value(board=board1, player_that_just_made_the_move="black")
-    result2 = get_board_value(board=board2, player_that_just_made_the_move="black")
+    result1 = get_board_value(
+        board=board1, player_that_just_made_the_move="black", last_move=None
+    )
+    result2 = get_board_value(
+        board=board2, player_that_just_made_the_move="black", last_move=None
+    )
 
     # then
     assert result1 >= result2
@@ -60,11 +68,15 @@ def test_get_board_value_is_infinite_when_in_checkmate():
     board = Board(board_string=board_string)
 
     # when
-    result_black = get_board_value(board=board, player_that_just_made_the_move="black")
-    result_white = get_board_value(board=board, player_that_just_made_the_move="white")
+    result_black = get_board_value(
+        board=board, player_that_just_made_the_move="black", last_move=None
+    )
+    result_white = get_board_value(
+        board=board, player_that_just_made_the_move="white", last_move=None
+    )
 
     # then
-    assert is_checkmate(board=board, current_player="white")
+    assert is_checkmate(board=board, current_player="white", last_move=None)
     assert result_black == float("inf")
     assert result_black == -result_white
 
@@ -87,10 +99,12 @@ def test_get_board_value_is_symmetric(current_player, opposite_player):
         result1 = get_board_value(
             board=board_after_move,
             player_that_just_made_the_move=current_player,
+            last_move=None,
         )
         result2 = get_board_value(
             board=board_after_move,
             player_that_just_made_the_move=opposite_player,
+            last_move=None,
         )
 
         # then

--- a/tests/test_move_validation.py
+++ b/tests/test_move_validation.py
@@ -3,71 +3,7 @@ import pytest
 from utahchess.board import Board
 from utahchess.move import REGULAR_MOVE, Move, make_move
 from utahchess.move_candidates import get_king_move_candidates, get_pawn_move_candidates
-from utahchess.move_validation import is_checkmate, is_valid_move
-
-
-def test_is_checkmate_fools_mate():
-    # when
-    board_string = f"""br-bn-bb-oo-bk-bb-bn-br
-            bp-bp-bp-bp-oo-bp-bp-bp
-            oo-oo-oo-oo-bp-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-wp-bq
-            oo-oo-oo-oo-oo-wp-oo-oo
-            wp-wp-wp-wp-wp-oo-oo-wp
-            wr-wn-wb-wq-wk-wb-wn-wr"""
-    board = Board(board_string=board_string)
-
-    # then
-    assert is_checkmate(board=board, current_player="white")
-
-
-def test_is_checkmate_friendly_piece_can_save_king():
-    # when
-    board_string = f"""br-oo-wq-bq-bk-bb-oo-br
-            bp-bp-oo-oo-oo-oo-oo-oo
-            bb-oo-oo-oo-oo-bp-oo-oo
-            wp-oo-wb-oo-oo-oo-oo-wb
-            oo-oo-oo-oo-oo-oo-oo-oo
-            wn-oo-oo-oo-oo-oo-oo-oo
-            oo-wp-wk-oo-oo-oo-wp-oo
-            oo-wr-oo-bn-oo-oo-wn-wr"""
-    board = Board(board_string=board_string)
-
-    # then
-    assert not is_checkmate(board=board, current_player="black")
-
-
-def test_is_checkmate_friendly_piece_can_save_king_two():
-    # when
-    board_string = f"""br-oo-oo-oo-oo-bb-oo-br
-            bp-bp-oo-bb-oo-oo-bp-bp
-            bn-oo-oo-bp-oo-bk-oo-oo
-            oo-wb-oo-oo-bp-oo-oo-oo
-            oo-oo-wp-oo-wp-wp-bn-oo
-            wp-oo-wp-oo-oo-oo-oo-oo
-            oo-wb-oo-oo-oo-bq-wp-wp
-            wr-wn-oo-oo-oo-wq-wk-wr"""
-    board = Board(board_string=board_string)
-
-    # then
-    assert not is_checkmate(board=board, current_player="white")
-
-
-def test_is_checkmate_another_scenario():
-    # when
-    board_string = f"""br-oo-oo-wq-oo-bk-oo-br
-            oo-oo-oo-oo-bn-oo-bp-oo
-            oo-wb-oo-oo-wp-bp-oo-oo
-            oo-bp-oo-oo-oo-wp-wn-oo
-            bq-wp-oo-oo-wp-oo-oo-bp
-            bb-oo-wp-oo-oo-oo-oo-oo
-            oo-oo-oo-oo-oo-oo-oo-oo
-            oo-wn-oo-wb-oo-wn-oo-wr"""
-    board = Board(board_string=board_string)
-
-    # then
-    assert not is_checkmate(board=board, current_player="black")
+from utahchess.move_validation import is_valid_move
 
 
 def test_is_valid_move_restricted_king():

--- a/utahchess/algebraic_notation.py
+++ b/utahchess/algebraic_notation.py
@@ -1,14 +1,7 @@
 from __future__ import annotations
 
 from utahchess.board import Board
-from utahchess.move import (
-    EN_PASSANT_MOVE,
-    LONG_CASTLING,
-    SHORT_CASTLING,
-    Move,
-    make_move,
-)
-from utahchess.move_validation import is_check, is_checkmate
+from utahchess.move import EN_PASSANT_MOVE, LONG_CASTLING, SHORT_CASTLING, Move
 from utahchess.utils import x_index_to_file, y_index_to_rank
 
 
@@ -20,7 +13,8 @@ def get_algebraic_identifer(move: Move, board: Board, **kwargs):
 
     For two moves on the same board the algebraic identifier can be ambiguous, meaning
     two moves can have the same identifier, if rank and file of the moving piece are
-    not considered. Rank and file paramters can be passed via **kwargs.
+    not considered. Rank and file paramters as well as a check or checkmate flag can
+    be passed via **kwargs.
 
     This function does thus not disambiguate a move's identifer. See
     "utahchess.legal_moves.get_move_per_algebraic_identifier" for that.
@@ -28,17 +22,19 @@ def get_algebraic_identifer(move: Move, board: Board, **kwargs):
     Args:
         move: Move for which to get the algebraic identifier for.
         board: Board on which move is executed.
-        **kwargs: Specifically for rank and file disambiguation.
+        **kwargs: Specifically for rank and file disambiguation and to pass check or
+            checkmate flag.
 
     Returns: A possibly ambiguous string describing the move in algebraic notation.
     """
     if move.type in (LONG_CASTLING, SHORT_CASTLING):
         return _get_castling_identifer(move=move)
-    check_or_checkmate_identifer = _get_check_or_checkmate_identifier(
-        board=board,
-        move=move,
-        current_player=move.moving_pieces[0].color,
-    )
+
+    try:
+        check_or_checkmate_identifer = kwargs["check_or_checkmate"]
+    except KeyError:
+        check_or_checkmate_identifer = ""
+
     try:
         rank = kwargs["rank"]
     except KeyError:
@@ -94,25 +90,3 @@ def _get_en_passant_identifier(move: Move) -> str:
     if move.type == EN_PASSANT_MOVE:
         return " e.p."
     return ""
-
-
-def _get_check_or_checkmate_identifier(
-    board: Board, move: Move, current_player: str
-) -> str:
-
-    if is_checkmate(
-        board=make_move(board=board, move=move),
-        current_player=_get_opposite_player(current_player=current_player),
-    ):
-        return "#"
-    elif is_check(
-        board=make_move(board=board, move=move),
-        current_player=_get_opposite_player(current_player=current_player),
-    ):
-        return "+"
-    else:
-        return ""
-
-
-def _get_opposite_player(current_player: str) -> str:
-    return "black" if current_player == "white" else "white"

--- a/utahchess/algebraic_notation.py
+++ b/utahchess/algebraic_notation.py
@@ -31,9 +31,9 @@ def get_algebraic_identifer(move: Move, board: Board, **kwargs):
         return _get_castling_identifer(move=move)
 
     try:
-        check_or_checkmate_identifer = kwargs["check_or_checkmate"]
+        check_or_checkmate = kwargs["check_or_checkmate"]
     except KeyError:
-        check_or_checkmate_identifer = ""
+        check_or_checkmate = ""
 
     try:
         rank = kwargs["rank"]
@@ -47,7 +47,7 @@ def get_algebraic_identifer(move: Move, board: Board, **kwargs):
     return (
         f"{_get_moving_piece_signifier(move=move)}{rank}{file}"
         f"{_get_capturing_flag(move=move)}{_get_destination_tile(move=move)}"
-        f"{_get_en_passant_identifier(move=move)}{check_or_checkmate_identifer}"
+        f"{_get_en_passant_identifier(move=move)}{check_or_checkmate}"
     )
 
 

--- a/utahchess/chess.py
+++ b/utahchess/chess.py
@@ -74,6 +74,7 @@ class ChessGame:
         return is_checkmate(
             board=self.current_game_state.board,
             current_player=self.get_current_player(),
+            last_move=self.current_game_state.last_move,
         ) or is_stalemate(
             board=self.current_game_state.board,
             current_player=self.get_current_player(),

--- a/utahchess/chess.py
+++ b/utahchess/chess.py
@@ -4,9 +4,9 @@ from dataclasses import dataclass
 from typing import Optional, Sequence
 
 from utahchess.board import Board
-from utahchess.legal_moves import get_move_per_algebraic_identifier
+from utahchess.legal_moves import get_move_per_algebraic_identifier, is_checkmate
 from utahchess.move import Move, make_move
-from utahchess.move_validation import is_check, is_checkmate
+from utahchess.move_validation import is_check
 
 
 class ChessGame:

--- a/utahchess/legal_moves.py
+++ b/utahchess/legal_moves.py
@@ -52,6 +52,7 @@ def is_checkmate(
 
     Returns: Flag indicating whether the current player is in checkmate or not.
     """
+
     def all_possible_boards():
         for potential_move in _get_all_legal_moves(
             board=board, current_player=current_player, last_move=last_move

--- a/utahchess/legal_moves.py
+++ b/utahchess/legal_moves.py
@@ -41,9 +41,7 @@ def get_move_per_algebraic_identifier(
     return mapping
 
 
-def is_checkmate(
-    board: Board, current_player: str, last_move: Optional[Move] = None
-) -> bool:
+def is_checkmate(board: Board, current_player: str, last_move: Optional[Move]) -> bool:
     """Check if current player is in checkmate.
 
     Args:
@@ -90,7 +88,9 @@ def _get_ambiguous_algebraic_notation_mapping(
             move=legal_move,
             board=board,
             check_or_checkmate=_get_check_or_checkmate_identifier(
-                board=board, move=legal_move, current_player=current_player
+                board=board,
+                move=legal_move,
+                current_player=current_player,
             ),
         )
         mapping.setdefault(ambiguous_identifer, []).append(legal_move)
@@ -152,12 +152,15 @@ def _get_moving_piece_rank(move: Move) -> str:
 
 
 def _get_check_or_checkmate_identifier(
-    board: Board, move: Move, current_player: str
+    board: Board,
+    move: Move,
+    current_player: str,
 ) -> str:
 
     if is_checkmate(
         board=make_move(board=board, move=move),
         current_player=_get_opposite_player(current_player=current_player),
+        last_move=move,
     ):
         return "#"
     elif is_check(

--- a/utahchess/minimax.py
+++ b/utahchess/minimax.py
@@ -169,7 +169,9 @@ def create_children_from_parent(
         )
 
 
-def get_board_value(board: Board, player_that_just_made_the_move: str) -> float:
+def get_board_value(
+    board: Board, player_that_just_made_the_move: str, last_move: Optional[Move]
+) -> float:
     """Get ad-hoc evaluation of a board.
 
     This function gets the value of the board to the player that just made the move.
@@ -186,9 +188,12 @@ def get_board_value(board: Board, player_that_just_made_the_move: str) -> float:
     if is_checkmate(
         board=board,
         current_player=_get_enemy_color(friendly_color=player_that_just_made_the_move),
+        last_move=last_move,
     ):
         return +CHECKMATE_VALUE
-    elif is_checkmate(board=board, current_player=player_that_just_made_the_move):
+    elif is_checkmate(
+        board=board, current_player=player_that_just_made_the_move, last_move=last_move
+    ):
         return -CHECKMATE_VALUE
 
     value: float = 0.0
@@ -216,6 +221,7 @@ def get_node_value(node: Node):
     return get_board_value(
         board=node.board,
         player_that_just_made_the_move=_get_enemy_color(friendly_color=node.player),
+        last_move=node.last_move,
     )
 
 

--- a/utahchess/minimax.py
+++ b/utahchess/minimax.py
@@ -5,9 +5,8 @@ from itertools import product
 from typing import Any, Callable, Generator, Iterable, Optional
 
 from utahchess.board import Board
-from utahchess.legal_moves import get_move_per_algebraic_identifier
+from utahchess.legal_moves import get_move_per_algebraic_identifier, is_checkmate
 from utahchess.move import Move, make_move
-from utahchess.move_validation import is_checkmate
 
 PAWN_VALUE = 1
 BISHOP_VALUE = 3

--- a/utahchess/move_validation.py
+++ b/utahchess/move_validation.py
@@ -26,30 +26,6 @@ def is_check(board: Board, current_player: str) -> bool:
     ]
 
 
-def is_checkmate(board: Board, current_player: str) -> bool:
-    """Check if current player is in checkmate.
-
-    Args:
-        board: Board on which to check whether current player is in checkmate or not.
-        current_player: Player for which the check is done.
-
-    Returns: Flag indicating whether the current player is in checkmate or not.
-    """
-
-    def all_possible_boards():
-        all_move_candidates = get_all_move_candidates(
-            board=board, current_player=current_player
-        )
-        for move_candidate in all_move_candidates:
-            from_position, to_position = move_candidate
-            yield board.move_piece(from_position=from_position, to_position=to_position)
-
-    for possible_board in all_possible_boards():
-        if not is_check(board=possible_board, current_player=current_player):
-            return False
-    return is_check(board=board, current_player=current_player)
-
-
 def is_valid_move(board: Board, move: Move) -> bool:
     """Get whether move is valid given the board.
 


### PR DESCRIPTION
Previously `is_checkmate` would only check if regular moves were able to save the king but was neglecting en passant and castling moves. To have access to these moves (and to avoid circular dependencies) the function has to be moved to `legal_moves`. Extra tests were added to catch checkmates averted by en passant moves. Note that it's not necessary to check for castling moves as it is impossible to castle out of, through or into check.

The `get_algebraic_notation` function had to be ammended such that it consumes the check or checkmate flag directly instead of computing it itself. This is because `legal_moves` needs `get_algebraic_notation` and can thus not import `is_checkmate` and compute it itself. 