### PR TITLE
Rerun analysis

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -71,12 +71,12 @@ There are also three other shell scripts in the `bin` folder (`install_<placehol
 - The main loop in `utahchess.chess` shows how to play a game of chess in the command line using user input for both sides of the game.
 - To implement a game of chess yourself the utils `utahchess.move_validation.is_check`, `utahchess.legal_moves.is_checkmate` and `utahchess.legal_moves.is_stalemate` can be used to check the status of a board.
 ### GUI
-- The proof of concept GUI using pygame can be tried out by executing `python gui/pygame/pygame_gui.py`.
+- The proof of concept GUI using pygame can be tried out by executing `python gui/pygame/pygame.gui`.
 - The GUI allows the user to play against the CPU, powered by an alpha-beta pruned minimax algorithm.
 ### Minimax
 - An implementation of the minimax algorithm with alpha-beta pruning can be found in `utahchess.minimax`, called `minimax`. 
 - A small helper class called `Node` can be used to provide the nodes necessary to navigate through the game tree.
-- The minimax function is general purpose and can be used for other games by providing appropriate `get_children` and `value function` parameters.
+- The minimax function is general purpose and be used for other games by providing appropriate `get_children` and `value function` parameters.
 - Implementations of those two parameters which can be used with the chess engine can be found in the module itself: `get_node_value` and `create_children_from_parent`.
   
 ## Miscellaneous
@@ -89,21 +89,24 @@ As expected the performance gain of alpha-beta pruning and the moves ordering ca
 
 | Depth | Number of boards | Baseline [s] | Only pruned [s] | Pruned and ordered [s] |
 | ----- | ---------------- | ------------ | --------------- | ---------------------- |
-| 1     | 100              | 1.96         | 1.91            | 1.87                   |
-| 2     | 50               | 36           | 22              | 25                     |
-| 3     | 10               | 199          | 35              | 11                     |
-| 4     | 10               | 8237         | 210             | 154                    |
-| 5     | 10               | N/A          | 2874            | 313                    |
+| 1     | 100              | 3            | 3               | 3                      |
+| 2     | 50               | 57           | 33              | 36                     |
+| 3     | 50               | 1901         | 284             | 125                    |
+| 4     | 50               | N/A          | 2902            | 4650                   |
+| 5     | 50               | N/A          | 27672           | 4462                   |
 
 Same table but with number of seconds per board:
 
 | Depth | Number of boards | Baseline [s/board] | Only pruned [s/board] | Pruned and ordered [s/board] |
 | ----- | ---------------- | ------------------ | --------------------- | ---------------------------- |
-| 1     | 100              | 0.0196             | 0.0191                | 0.0187                       |
-| 2     | 50               | 0.72               | 0.44                  | 0.5                          |
-| 3     | 10               | 19.9               | 3.5                   | 1.1                          |
-| 4     | 10               | 823.7              | 21                    | 15.4                         |
-| 5     | 10               | N/A                | 287.4                 | 31.3                         |
+| 1     | 100              | 0.03               | 0.03                  | 0.03                         |
+| 2     | 50               | 1.15               | 0.67                  | 0.72                         |
+| 3     | 50               | 38                 | 5.7                   | 2.5                          |
+| 4     | 50               | N/A                | 56                    | 93                           |
+| 5     | 50               | N/A                | 553                   | 89                           |
+
+Note that the baseline was omitted past depth 3 since it is very slow. In a different run the baseline was run on 10 boards at depth 4 and it already took more than an hour (8200 seconds specifically).
+It is interesting to see that the 'only pruned' experiment actually performs better than the 'pruned and ordered' one at depth 4. Note that the 50 boards are the same at every level. It seems like the ad-hoc ordering function actually makes the algorithms job harder at depth 4 which is strange since even at depth 3 we can see an improvement on the same boards. The improvement is obvious again at depth 5.
 
 ### Some pygame GUI screenshots
 | Initial board                                                                    | Board after some moves                                                             | Available moves for knight                                                         |

--- a/analyses/alpha_beta_performance_increase/analysis.py
+++ b/analyses/alpha_beta_performance_increase/analysis.py
@@ -74,10 +74,13 @@ if __name__ == "__main__":
                 num_boards=NUM_BOARDS,
             )
         )
+        average_num_pieces = sum(
+            len(tuple(board.all_pieces())) for board, _ in dataset
+        ) / len(dataset)
         print(
             f"Loaded dataset with {len(dataset)} boards. "
             f"On average these boards contain "
-            f"{sum(len(tuple(board.all_pieces())) for board, _ in dataset)/len(dataset)} "
+            f"{average_num_pieces} "
             f"pieces. \nWith a maximum of "
             f"{max(len(tuple(board.all_pieces())) for board, _ in dataset)} pieces "
             f"and a minimum of "

--- a/analyses/alpha_beta_performance_increase/analysis.py
+++ b/analyses/alpha_beta_performance_increase/analysis.py
@@ -12,22 +12,25 @@ from utahchess.minimax import Node, create_children_from_parent, get_node_value,
 
 def generate_dataset(
     dataset_path: str, num_boards: int
-) -> Generator[Board, None, None]:
+) -> Generator[tuple[Board, str], None, None]:
+    """Read and yield a number of board strings read from files."""
     for root, _, filenames in walk(dataset_path):
         for count, filename in enumerate(filenames):
             if count == num_boards:
                 break
             with open(f"{root}/{filename}", "r") as file:
-                yield Board(board_string=file.read())
+                yield Board(board_string=file.read()), filename
 
 
 def run_experiment(
-    dataset: Sequence[Board], depth: int, order: bool, prune: bool
-) -> tuple[float, list[float]]:
-
+    dataset: Sequence[tuple[Board, str]], depth: int, order: bool, prune: bool
+) -> tuple[float, list[float], list[str], list[str]]:
+    """Run minimax algorithm at given depth for all boards in the dataset."""
     start = time.time()
     found_values = []
-    for board in dataset:
+    found_nodes = []
+    filenames = []
+    for board, filename in dataset:
 
         parent_node = Node(
             name="initial_node",
@@ -47,12 +50,22 @@ def run_experiment(
             prune=prune,
         )
         found_values.append(value)
-    return time.time() - start, found_values
+        found_nodes.append(suggested_node.name)
+        filenames.append(filename)
+    return time.time() - start, found_values, found_nodes, filenames
+
+
+def report_results(time: float, type: str, num_boards: int) -> None:
+    print(
+        f"Experiment of type '{type}' took {time:.2f} seconds to run. "
+        f"This implies each board took {time/num_boards:.2f} seconds to process."
+    )
 
 
 if __name__ == "__main__":
 
-    for DEPTH, NUM_BOARDS in zip((1, 2, 3, 4, 5), (100, 50, 10, 10, 10)):
+    for DEPTH, NUM_BOARDS in zip((1, 2, 3, 4, 5), (100, 50, 50, 50, 50)):
+        print("=====================================================================")
         print("DEPTH:", DEPTH)
         print("NUM_BOARDS:", NUM_BOARDS)
         dataset = tuple(
@@ -64,52 +77,41 @@ if __name__ == "__main__":
         print(
             f"Loaded dataset with {len(dataset)} boards. "
             f"On average these boards contain "
-            f"{sum(len(tuple(board.all_pieces())) for board in dataset)/len(dataset)} "
+            f"{sum(len(tuple(board.all_pieces())) for board, _ in dataset)/len(dataset)} "
             f"pieces. \nWith a maximum of "
-            f"{max(len(tuple(board.all_pieces())) for board in dataset)} pieces "
+            f"{max(len(tuple(board.all_pieces())) for board, _ in dataset)} pieces "
             f"and a minimum of "
-            f" {min(len(tuple(board.all_pieces())) for board in dataset)} pieces."
+            f"{min(len(tuple(board.all_pieces())) for board, _ in dataset)} pieces."
         )
 
-        print("Working on ordered and pruned experiment...")
-        ordered_and_pruned_time, ordered_and_pruned_values = run_experiment(
-            dataset=dataset, depth=DEPTH, order=True, prune=True
-        )
-        print(
-            "Ordered and pruned finished after",
+        (
             ordered_and_pruned_time,
-            "seconds",
-        )
-        print("Working on just pruned experiment...")
-        just_pruned_time, just_pruned_values = run_experiment(
-            dataset=dataset, depth=DEPTH, order=False, prune=True
-        )
-        print("Just pruned finished after", just_pruned_time, "seconds")
-        if DEPTH <= 4:
-            print("Working on baseline experiment...")
-            baseline_time, baseline_values = run_experiment(
-                dataset=dataset, depth=DEPTH, order=False, prune=False
-            )
-            print("Baseline finished after", baseline_time, "seconds")
+            ordered_and_pruned_values,
+            ordered_and_pruned_node_names,
+            ordered_and_pruned_node_filenames,
+        ) = run_experiment(dataset=dataset, depth=DEPTH, order=True, prune=True)
+        (
+            just_pruned_time,
+            just_pruned_values,
+            just_pruned_node_names,
+            just_pruned_filenames,
+        ) = run_experiment(dataset=dataset, depth=DEPTH, order=False, prune=True)
 
-        print("\n")
-        print("Times:")
-        print(ordered_and_pruned_time)
-        print(just_pruned_time)
-        if DEPTH <= 4:
-            print(baseline_time)
-
-        print(ordered_and_pruned_values)
-        print(just_pruned_values)
-        if DEPTH <= 4:
-            print(baseline_values)
-        print("\n")
-        print("-------------------------------------------------")
-        print("-------------------------------------------------")
-        print("-------------------------------------------------")
-        print("\n")
-
+        # Assert all algorithms found the same values
         assert ordered_and_pruned_values == just_pruned_values
-        if DEPTH <= 4:
+        for experiment_time, type in zip(
+            (ordered_and_pruned_time, just_pruned_time),
+            ("ordered and pruned", "only pruned"),
+        ):
+            report_results(time=experiment_time, type=type, num_boards=NUM_BOARDS)
+
+        if DEPTH < 4:
+            (
+                baseline_time,
+                baseline_values,
+                baseline_node_names,
+                baseline_filenames,
+            ) = run_experiment(dataset=dataset, depth=DEPTH, order=False, prune=False)
             assert just_pruned_values == baseline_values
             assert baseline_values == ordered_and_pruned_values
+            report_results(time=baseline_time, type="baseline", num_boards=NUM_BOARDS)

--- a/analyses/alpha_beta_performance_increase/create_dataset.py
+++ b/analyses/alpha_beta_performance_increase/create_dataset.py
@@ -19,11 +19,29 @@ IMBALANCE_RANGE_HIGH = 0.7
 
 
 def sample_n_positions(n: int) -> list[tuple[int, int]]:
+    """Generate n positions on a chess board at random."""
     random.shuffle(POSSIBLE_INDICES)
     return list(ALL_POSITIONS[i] for i in POSSIBLE_INDICES[:n])
 
 
 def sample_random_board(n_pieces: int) -> Board:
+    """Generate semi-random chess board.
+
+    The board is configured by first placing the king of each color.
+    The amount of pieces left to distribute are allocated at random between 30% white
+    and 70% white.
+    Types of pieces are randomly sampled according to their occurence. This means a
+    white rook is twice as likely to appear than a white queen but is four time less
+    like to appear than a white pawn.
+    In the end the procedure is repeated if the resulting board is arleady in check or
+    checkmate.
+
+    Args:
+        n_pieces: Number of pieces to distribute on the board.
+
+    Returns: A board with randomly distributed pieces placed on it. Always contains
+        each color's king and is never in check or checkmate.
+    """
     board_pieces: list[Piece] = []
     positions_to_fill = sample_n_positions(n=n_pieces)
     # place two kings
@@ -129,7 +147,7 @@ if __name__ == "__main__":
     NUM_BOARDS = 1000
     count = 0
     while count < NUM_BOARDS:
-        num_pieces = int(random.uniform(3, 20))
+        num_pieces = int(random.uniform(6, 20))
         board = sample_random_board(n_pieces=num_pieces)
         count += 1
         if count % 10 == 0:

--- a/analyses/alpha_beta_performance_increase/results_run_2.txt
+++ b/analyses/alpha_beta_performance_increase/results_run_2.txt
@@ -1,0 +1,38 @@
+=====================================================================
+DEPTH: 1
+NUM_BOARDS: 100
+Loaded dataset with 100 boards. On average these boards contain 12.42 pieces. 
+With a maximum of 19 pieces and a minimum of 6 pieces.
+Experiment of type 'ordered and pruned' took 3.25 seconds to run. This implies each board took 0.03 seconds to process.
+Experiment of type 'only pruned' took 3.16 seconds to run. This implies each board took 0.03 seconds to process.
+Experiment of type 'baseline' took 3.22 seconds to run. This implies each board took 0.03 seconds to process.
+=====================================================================
+DEPTH: 2
+NUM_BOARDS: 50
+Loaded dataset with 50 boards. On average these boards contain 12.9 pieces. 
+With a maximum of 19 pieces and a minimum of 6 pieces.
+Experiment of type 'ordered and pruned' took 36.02 seconds to run. This implies each board took 0.72 seconds to process.
+Experiment of type 'only pruned' took 32.40 seconds to run. This implies each board took 0.65 seconds to process.
+Experiment of type 'baseline' took 56.56 seconds to run. This implies each board took 1.13 seconds to process.
+=====================================================================
+DEPTH: 3
+NUM_BOARDS: 10
+Loaded dataset with 10 boards. On average these boards contain 12.6 pieces. 
+With a maximum of 18 pieces and a minimum of 6 pieces.
+Experiment of type 'ordered and pruned' took 19.29 seconds to run. This implies each board took 1.93 seconds to process.
+Experiment of type 'only pruned' took 42.54 seconds to run. This implies each board took 4.25 seconds to process.
+Experiment of type 'baseline' took 261.26 seconds to run. This implies each board took 26.13 seconds to process.
+=====================================================================
+DEPTH: 4
+NUM_BOARDS: 10
+Loaded dataset with 10 boards. On average these boards contain 12.6 pieces. 
+With a maximum of 18 pieces and a minimum of 6 pieces.
+Experiment of type 'ordered and pruned' took 711.85 seconds to run. This implies each board took 71.19 seconds to process.
+Experiment of type 'only pruned' took 423.43 seconds to run. This implies each board took 42.34 seconds to process.
+=====================================================================
+DEPTH: 5
+NUM_BOARDS: 10
+Loaded dataset with 10 boards. On average these boards contain 12.6 pieces. 
+With a maximum of 18 pieces and a minimum of 6 pieces.
+Experiment of type 'ordered and pruned' took 810.50 seconds to run. This implies each board took 81.05 seconds to process.
+Experiment of type 'only pruned' took 6084.64 seconds to run. This implies each board took 608.46 seconds to process.

--- a/analyses/alpha_beta_performance_increase/results_run_3.txt
+++ b/analyses/alpha_beta_performance_increase/results_run_3.txt
@@ -1,0 +1,38 @@
+=====================================================================
+DEPTH: 1
+NUM_BOARDS: 100
+Loaded dataset with 100 boards. On average these boards contain 12.42 pieces. 
+With a maximum of 19 pieces and a minimum of 6 pieces.
+Experiment of type 'ordered and pruned' took 3.25 seconds to run. This implies each board took 0.03 seconds to process.
+Experiment of type 'only pruned' took 3.27 seconds to run. This implies each board took 0.03 seconds to process.
+Experiment of type 'baseline' took 3.22 seconds to run. This implies each board took 0.03 seconds to process.
+=====================================================================
+DEPTH: 2
+NUM_BOARDS: 50
+Loaded dataset with 50 boards. On average these boards contain 12.9 pieces. 
+With a maximum of 19 pieces and a minimum of 6 pieces.
+Experiment of type 'ordered and pruned' took 36.16 seconds to run. This implies each board took 0.72 seconds to process.
+Experiment of type 'only pruned' took 33.35 seconds to run. This implies each board took 0.67 seconds to process.
+Experiment of type 'baseline' took 57.42 seconds to run. This implies each board took 1.15 seconds to process.
+=====================================================================
+DEPTH: 3
+NUM_BOARDS: 50
+Loaded dataset with 50 boards. On average these boards contain 12.9 pieces. 
+With a maximum of 19 pieces and a minimum of 6 pieces.
+Experiment of type 'ordered and pruned' took 124.38 seconds to run. This implies each board took 2.49 seconds to process.
+Experiment of type 'only pruned' took 283.53 seconds to run. This implies each board took 5.67 seconds to process.
+Experiment of type 'baseline' took 1901.40 seconds to run. This implies each board took 38.03 seconds to process.
+=====================================================================
+DEPTH: 4
+NUM_BOARDS: 50
+Loaded dataset with 50 boards. On average these boards contain 12.9 pieces. 
+With a maximum of 19 pieces and a minimum of 6 pieces.
+Experiment of type 'ordered and pruned' took 4650.92 seconds to run. This implies each board took 93.02 seconds to process.
+Experiment of type 'only pruned' took 2902.81 seconds to run. This implies each board took 58.06 seconds to process.
+=====================================================================
+DEPTH: 5
+NUM_BOARDS: 50
+Loaded dataset with 50 boards. On average these boards contain 12.9 pieces. 
+With a maximum of 19 pieces and a minimum of 6 pieces.
+Experiment of type 'ordered and pruned' took 4462.30 seconds to run. This implies each board took 89.25 seconds to process.
+Experiment of type 'only pruned' took 27672.62 seconds to run. This implies each board took 553.45 seconds to process.


### PR DESCRIPTION
This PR 

- does some mostly cosmetic changes to the minimax analysis by documenting its functions somewhat and keeping track of the filenames of the boards that were processed (which can help with debugging)
- ups the number of boards from 10 to 50 for depths 3 to 5
- ups the minimum number of pieceson the board from 3 to 6
- updates the README with the results of the rerun